### PR TITLE
Fix #2 - python2/3 support

### DIFF
--- a/python/protoc-gen-mypy
+++ b/python/protoc-gen-mypy
@@ -307,7 +307,11 @@ def main():
     output = response.SerializeToString()
 
     # Write to stdout
-    sys.stdout.write(output)
+    if six.PY3:
+        sys.stdout.buffer.write(output)
+    else:
+        sys.stdout.write(output)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fixes #2. Not sure how to test this.

I ran through the readme on using go to compile this and that went fine. But I'm getting dependancy errors when trying to run the python script.

Needed `google` from pip. Now I need `google.protobuf.descriptor_pb2` which I'm not sure where to get.