### PR TITLE
Fixes issue #4

### DIFF
--- a/python/protoc-gen-mypy
+++ b/python/protoc-gen-mypy
@@ -75,7 +75,7 @@ class PkgWriter(object):
         for i, segment in enumerate(split):
             if segment and segment[0].isupper():
                 assert message_fd.name.endswith('.proto')
-                import_name = self._import(message_fd.name[:-6], segment)
+                import_name = self._import(message_fd.name[:-6] + "_pb2", segment)
                 remains = ".".join(split[i + 1:])
                 if not remains:
                     return import_name


### PR DESCRIPTION
This pull request fixes issue #4 

I've tested in on my own machine with protos which import standard google protobuffs, and custom protobuf implementation. python_out adds _pb2 to module name and should be added in imports.