### PR TITLE
Convert proto3 maps into MutableMapping Python constructs

### DIFF
--- a/python/protoc-gen-mypy
+++ b/python/protoc-gen-mypy
@@ -150,7 +150,7 @@ class PkgWriter(object):
                         msg = self.descriptors.messages[field.type_name]
                         if msg.options.map_entry:
                             # map generates a special Entry wrapper message
-                            container = self._import("google.protobuf.internal.containers", "MutableMapping")
+                            container = self._import("typing", "MutableMapping")
                             l("def {}(self) -> {}[{}, {}]: ...", field.name, container, self.python_type(msg.field[0]), self.python_type(msg.field[1]))
                         else:
                             container = self._import("google.protobuf.internal.containers", "RepeatedScalarFieldContainer")
@@ -167,8 +167,13 @@ class PkgWriter(object):
                         l("{} : {},", field.name, self.python_type(field))
                     for field in [f for f in desc.field if f.label != d.FieldDescriptorProto.LABEL_REQUIRED]:
                         if field.label == d.FieldDescriptorProto.LABEL_REPEATED:
-                            l("{} : {}[{}] = None,", field.name,
-                              self._import("typing", "Iterable"), self.python_type(field))
+                            if field.type_name != '' and self.descriptors.messages[field.type_name].options.map_entry:
+                                msg = self.descriptors.messages[field.type_name]
+                                l("{} : {}[{}, {}] = None,", field.name,
+                                    self._import("typing", "Mapping"), self.python_type(msg.field[0]), self.python_type(msg.field[1]))
+                            else:
+                                l("{} : {}[{}] = None,", field.name,
+                                  self._import("typing", "Iterable"), self.python_type(field))
                         else:
                             l("{} : {} = None,", field.name, self.python_type(field))
                     l(") -> None: ...")

--- a/python/protoc-gen-mypy
+++ b/python/protoc-gen-mypy
@@ -153,7 +153,7 @@ class PkgWriter(object):
                             container = self._import("typing", "MutableMapping")
                             l("def {}(self) -> {}[{}, {}]: ...", field.name, container, self.python_type(msg.field[0]), self.python_type(msg.field[1]))
                         else:
-                            container = self._import("google.protobuf.internal.containers", "RepeatedScalarFieldContainer")
+                            container = self._import("google.protobuf.internal.containers", "RepeatedCompositeFieldContainer")
                             l("def {}(self) -> {}[{}]: ...", field.name, container, self.python_type(field))
                     else:
                         l("def {}(self) -> {}: ...", field.name, self.python_type(field))

--- a/python/protoc-gen-mypy
+++ b/python/protoc-gen-mypy
@@ -147,8 +147,14 @@ class PkgWriter(object):
                 for field in [f for f in desc.field if not is_scalar(f)]:
                     l("@property")
                     if field.label == d.FieldDescriptorProto.LABEL_REPEATED:
-                        container = self._import("google.protobuf.internal.containers", "RepeatedScalarFieldContainer")
-                        l("def {}(self) -> {}[{}]: ...", field.name, container, self.python_type(field))
+                        msg = self.descriptors.messages[field.type_name]
+                        if msg.options.map_entry:
+                            # map generates a special Entry wrapper message
+                            container = self._import("google.protobuf.internal.containers", "MutableMapping")
+                            l("def {}(self) -> {}[{}, {}]: ...", field.name, container, self.python_type(msg.field[0]), self.python_type(msg.field[1]))
+                        else:
+                            container = self._import("google.protobuf.internal.containers", "RepeatedScalarFieldContainer")
+                            l("def {}(self) -> {}[{}]: ...", field.name, container, self.python_type(field))
                     else:
                         l("def {}(self) -> {}: ...", field.name, self.python_type(field))
                     l("")
@@ -270,7 +276,7 @@ class Descriptors(object):
         to_generate = {n: files[n] for n in request.file_to_generate}
         self.files = files  # type: Dict[Text, d.FileDescriptorProto]
         self.to_generate = to_generate  # type: Dict[Text, d.FileDescriptorProto]
-
+        self.messages = {} # type: Dict[Text, d.DescriptorProto]
         self.message_to_fd = {}  # type: Dict[Text, d.FileDescriptorProto]
 
         def _add_enums(enums, prefix, fd):
@@ -281,6 +287,7 @@ class Descriptors(object):
         def _add_messages(messages, prefix, fd):
             # type: (d.DescriptorProto, Text) -> None
             for message in messages:
+                self.messages[prefix + message.name] = message
                 self.message_to_fd[prefix + message.name] = fd
                 sub_prefix = prefix + message.name + "."
                 _add_messages(message.nested_type, sub_prefix, fd)


### PR DESCRIPTION
Here's an example of converting proto3 maps into MutableMapping types rather than defaulting to RepeatedScalarFieldContainer constructs...

Referencing #12 for more context.
