### PR TITLE
Use local imports to get other generated type stubs

### DIFF
--- a/python/protoc-gen-mypy
+++ b/python/protoc-gen-mypy
@@ -83,7 +83,7 @@ class PkgWriter(object):
         for i, segment in enumerate(split):
             if segment and segment[0].isupper():
                 assert message_fd.name.endswith('.proto')
-                import_name = self._import(message_fd.name[:-6].replace('-', '_') + "_pb2", segment)
+                import_name = self._import("." + message_fd.name[:-6].replace('-', '_') + "_pb2", segment)
                 remains = ".".join(split[i + 1:])
                 if not remains:
                     return import_name


### PR DESCRIPTION
When the protobuf type stubs don't live as top level packages, they need to import each other using local imports.