### PR TITLE
Disambiguate import name collisions for enums too

### DIFF
--- a/go/src/protoc-gen-mypy/main.go
+++ b/go/src/protoc-gen-mypy/main.go
@@ -443,6 +443,7 @@ func (w *pkgWriter) WriteEnums(enums []*descriptor.EnumDescriptorProto, prefix s
 
 	text := w.Name("typing", "Text")
 	for i, enumType := range enums {
+		w.RegisterLocal(enumType.GetName())
 		// Protobuf enums are instances of EnumWrapperType which is not a proper Python
 		// enum. In order to type check properly we create a custom class for each enum with
 		// the same interface as EnumWrapperType but extending int.


### PR DESCRIPTION
Makes it so, for example, you can have an `enum ErrorCode` in a package that imports another package with an `enum ErrorCode`, which used to cause a redefinition error.

The old way used to produce something like this:
```
from dropbox.proto.other_package.other_package_pb2 import (
        ErrorCode,
)

class ErrorCode(int):
```
and now it makes:
```
from dropbox.proto.other_package.other_package_pb2 import (
        ErrorCode as ErrorCode1,
)

class ErrorCode(int):
```