### PR TITLE
update filepath generation to match the behaviour of protoc --python-out

### DIFF
--- a/proto/test/proto/github.com/test/test.proto
+++ b/proto/test/proto/github.com/test/test.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+package test;
+
+message TestMessage {
+	string foo = 1;
+}

--- a/python/protoc-gen-mypy
+++ b/python/protoc-gen-mypy
@@ -378,7 +378,8 @@ def generate_mypy_stubs(descriptors, response, quiet):
         assert name == fd.name
         assert fd.name.endswith('.proto')
         output = response.file.add()
-        output.name = fd.name[:-6].replace('-', '_') + '_pb2.pyi'
+        output.name = fd.name[:-6].replace('-', '_')
+        output.name = output.name.replace('.', '/') + '_pb2.pyi'
         output.content = HEADER + pkg_writer.write()
         if not quiet:
             print("Writing mypy to", output.name, file=sys.stderr)


### PR DESCRIPTION
Hey! thanks for building this 🙏 

We're using some pretty long path proto defintions like:
github.com/monzo/foobar/service.my-cool-service/proto/mything.proto
and --python-out will replace all instances of `.` with a `/` for cleaner python imports or something.
in the python implementation mypy doesn't do this, so we end up with the _pb2.py files in a different directory to the _pb2.pyi files. this PR updates the generator to bring the two in line.