### PR TITLE
Support inner enum constants

### DIFF
--- a/python/protoc-gen-mypy
+++ b/python/protoc-gen-mypy
@@ -146,6 +146,13 @@ class PkgWriter(object):
         else:
             self.lines.append(self.indent + line.format(*args))
 
+    def write_enum_values(self, enum, prefix):
+        for val in enum.value:
+            if val.name in PYTHON_RESERVED:
+                continue
+
+            self._write_line("{}: {}[{}]", val.name, self._import("typing_extensions", "Literal"), val.number)
+
     def write_enums(self, enums, prefix=''):
         # type: (Iterable[d.EnumDescriptorProto], Text) -> None
         l = self._write_line
@@ -171,8 +178,10 @@ class PkgWriter(object):
                     self._import("typing", "List"),
                     self._import("typing", "Tuple"))
 
-            for val in enum.value:
-                l("{}: {}[{}]", val.name, self._import("typing_extensions", "Literal"), val.number)
+                self.write_enum_values(enum, prefix)
+
+            self.write_enum_values(enum, prefix)
+
             l("")
 
     def write_messages(self, messages, prefix):

--- a/test/proto/nested/nested_pb2.pyi.expected
+++ b/test/proto/nested/nested_pb2.pyi.expected
@@ -56,6 +56,9 @@ class AnotherNested(google___protobuf___message___Message):
         def values(cls) -> typing___List[ClosedValueType]: ...
         @classmethod
         def items(cls) -> typing___List[typing___Tuple[ClosedKeyType, ClosedValueType]]: ...
+        INVALID: typing_extensions___Literal[0]
+        ONE: typing_extensions___Literal[1]
+        TWO: typing_extensions___Literal[2]
     INVALID: typing_extensions___Literal[0]
     ONE: typing_extensions___Literal[1]
     TWO: typing_extensions___Literal[2]
@@ -75,6 +78,9 @@ class AnotherNested(google___protobuf___message___Message):
             def values(cls) -> typing___List[ClosedValueType]: ...
             @classmethod
             def items(cls) -> typing___List[typing___Tuple[ClosedKeyType, ClosedValueType]]: ...
+            UNDEFINED: typing_extensions___Literal[0]
+            NESTED_ENUM1: typing_extensions___Literal[1]
+            NESTED_ENUM2: typing_extensions___Literal[2]
         UNDEFINED: typing_extensions___Literal[0]
         NESTED_ENUM1: typing_extensions___Literal[1]
         NESTED_ENUM2: typing_extensions___Literal[2]

--- a/test/proto/test3_pb2.pyi.expected
+++ b/test/proto/test3_pb2.pyi.expected
@@ -41,6 +41,9 @@ class OuterEnum(object):
     def values(cls) -> typing___List[ClosedValueType]: ...
     @classmethod
     def items(cls) -> typing___List[typing___Tuple[ClosedKeyType, ClosedValueType]]: ...
+    UNKNOWN: typing_extensions___Literal[0]
+    FOO3: typing_extensions___Literal[1]
+    BAR3: typing_extensions___Literal[2]
 UNKNOWN: typing_extensions___Literal[0]
 FOO3: typing_extensions___Literal[1]
 BAR3: typing_extensions___Literal[2]

--- a/test/proto/test_pb2.pyi.expected
+++ b/test/proto/test_pb2.pyi.expected
@@ -74,6 +74,8 @@ class OuterEnum(object):
     def values(cls) -> typing___List[ClosedValueType]: ...
     @classmethod
     def items(cls) -> typing___List[typing___Tuple[ClosedKeyType, ClosedValueType]]: ...
+    FOO: typing_extensions___Literal[1]
+    BAR: typing_extensions___Literal[2]
 FOO: typing_extensions___Literal[1]
 BAR: typing_extensions___Literal[2]
 
@@ -92,6 +94,8 @@ class Simple1(google___protobuf___message___Message):
         def values(cls) -> typing___List[ClosedValueType]: ...
         @classmethod
         def items(cls) -> typing___List[typing___Tuple[ClosedKeyType, ClosedValueType]]: ...
+        INNER1: typing_extensions___Literal[1]
+        INNER2: typing_extensions___Literal[2]
     INNER1: typing_extensions___Literal[1]
     INNER2: typing_extensions___Literal[2]
 

--- a/test/test_generated_mypy.py
+++ b/test/test_generated_mypy.py
@@ -80,6 +80,9 @@ def test_func():
     s.a_repeated_string.append("Hello")
     s.a_enum = FOO
     assert s.a_enum == FOO
+    if False:  # requires Protobuf >=3.8
+        s.a_enum = OuterEnum.FOO
+        assert s.a_enum == FOO
     s.a_enum = 1
     assert s.a_enum == FOO
     assert FOO == 1


### PR DESCRIPTION
In Python protobufs, enum members can be accessed both as `module.ENUM_MEMBER` or `module.MyEnum.ENUM_MEMBER`.

This commit adds support for the latter style.

It also fixes a problem with using reserved keywords as an enum member name (declarations for those are skipped).