### PR TITLE
Use absolute path to necessary python.

### DIFF
--- a/python/protoc_gen_mypy.bat
+++ b/python/protoc_gen_mypy.bat
@@ -1,2 +1,2 @@
 @echo off
-python -u %0\..\protoc-gen-mypy
+%~dp0\python -u %0\..\protoc-gen-mypy


### PR DESCRIPTION
It will prevent calling system python instead of python in venv.
Why system python was called instead of local? I don't know) But this fix helps.