### PR TITLE
Split Enum value type from EnumTypeWrapper

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -4,6 +4,9 @@ PY_VERSION=`python -c 'import sys; print(sys.version.split()[0])'`
 VENV=venv_$PY_VERSION
 MYPY_VENV=venv_mypy
 
+RED="\033[0;31m"
+NC='\033[0m'
+
 (
     # Create virtualenv + Install requirements for mypy-protobuf
     if [[ -z $SKIP_CLEAN ]] || [[ ! -e $VENV ]]; then
@@ -36,7 +39,7 @@ MYPY_VENV=venv_mypy
     for PY in 2.7 3.5; do
         mypy --python-version=$PY python/mypy_protobuf.py test/
         if ! diff <(mypy --python-version=$PY python/mypy_protobuf.py test_negative/) test_negative/output.expected.$PY; then
-            echo "test_negative/output.expected.$PY didnt match. Copying over for you. Now rerun"
+            echo -e "${RED}test_negative/output.expected.$PY didnt match. Copying over for you. Now rerun${NC}"
             for PY in 2.7 3.5; do
                 mypy --python-version=$PY python/mypy_protobuf.py test_negative/ > test_negative/output.expected.$PY || true
             done

--- a/test/proto/inner/inner_pb2.pyi.expected
+++ b/test/proto/inner/inner_pb2.pyi.expected
@@ -9,7 +9,7 @@ from google.protobuf.message import (
 )
 
 from test.proto.test3_pb2 import (
-    OuterEnum as test___proto___test3_pb2___OuterEnum,
+    OuterEnumValue as test___proto___test3_pb2___OuterEnumValue,
 )
 
 from typing import (
@@ -33,11 +33,11 @@ if sys.version_info < (3,):
 
 class Inner(google___protobuf___message___Message):
     DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
-    a: test___proto___test3_pb2___OuterEnum = ...
+    a: test___proto___test3_pb2___OuterEnumValue = ...
 
     def __init__(self,
         *,
-        a : typing___Optional[test___proto___test3_pb2___OuterEnum] = None,
+        a : typing___Optional[test___proto___test3_pb2___OuterEnumValue] = None,
         ) -> None: ...
     if sys.version_info >= (3,):
         @classmethod

--- a/test/proto/nested/nested_pb2.pyi.expected
+++ b/test/proto/nested/nested_pb2.pyi.expected
@@ -10,11 +10,12 @@ from google.protobuf.message import (
 )
 
 from test.proto.test3_pb2 import (
-    OuterEnum as test___proto___test3_pb2___OuterEnum,
+    OuterEnumValue as test___proto___test3_pb2___OuterEnumValue,
 )
 
 from typing import (
     List as typing___List,
+    NewType as typing___NewType,
     Optional as typing___Optional,
     Text as typing___Text,
     Tuple as typing___Tuple,
@@ -39,11 +40,11 @@ if sys.version_info < (3,):
 
 class Nested(google___protobuf___message___Message):
     DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
-    a: test___proto___test3_pb2___OuterEnum = ...
+    a: test___proto___test3_pb2___OuterEnumValue = ...
 
     def __init__(self,
         *,
-        a : typing___Optional[test___proto___test3_pb2___OuterEnum] = None,
+        a : typing___Optional[test___proto___test3_pb2___OuterEnumValue] = None,
         ) -> None: ...
     if sys.version_info >= (3,):
         @classmethod
@@ -58,59 +59,63 @@ global___Nested = Nested
 
 class AnotherNested(google___protobuf___message___Message):
     DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
-    class NestedEnum(builtin___int):
+    NestedEnumValue = typing___NewType('NestedEnumValue', builtin___int)
+    global___NestedEnumValue = NestedEnumValue
+    class NestedEnum(object):
         DESCRIPTOR: google___protobuf___descriptor___EnumDescriptor = ...
         @classmethod
         def Name(cls, number: builtin___int) -> builtin___str: ...
         @classmethod
-        def Value(cls, name: builtin___str) -> 'AnotherNested.NestedEnum': ...
+        def Value(cls, name: builtin___str) -> AnotherNested.NestedEnumValue: ...
         @classmethod
         def keys(cls) -> typing___List[builtin___str]: ...
         @classmethod
-        def values(cls) -> typing___List['AnotherNested.NestedEnum']: ...
+        def values(cls) -> typing___List[AnotherNested.NestedEnumValue]: ...
         @classmethod
-        def items(cls) -> typing___List[typing___Tuple[builtin___str, 'AnotherNested.NestedEnum']]: ...
-        INVALID = typing___cast('AnotherNested.NestedEnum', 0)
-        ONE = typing___cast('AnotherNested.NestedEnum', 1)
-        TWO = typing___cast('AnotherNested.NestedEnum', 2)
-    INVALID = typing___cast('AnotherNested.NestedEnum', 0)
-    ONE = typing___cast('AnotherNested.NestedEnum', 1)
-    TWO = typing___cast('AnotherNested.NestedEnum', 2)
+        def items(cls) -> typing___List[typing___Tuple[builtin___str, AnotherNested.NestedEnumValue]]: ...
+        INVALID = typing___cast(AnotherNested.NestedEnumValue, 0)
+        ONE = typing___cast(AnotherNested.NestedEnumValue, 1)
+        TWO = typing___cast(AnotherNested.NestedEnumValue, 2)
+    INVALID = typing___cast(AnotherNested.NestedEnumValue, 0)
+    ONE = typing___cast(AnotherNested.NestedEnumValue, 1)
+    TWO = typing___cast(AnotherNested.NestedEnumValue, 2)
     global___NestedEnum = NestedEnum
 
     class NestedMessage(google___protobuf___message___Message):
         DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
-        class NestedEnum2(builtin___int):
+        NestedEnum2Value = typing___NewType('NestedEnum2Value', builtin___int)
+        global___NestedEnum2Value = NestedEnum2Value
+        class NestedEnum2(object):
             DESCRIPTOR: google___protobuf___descriptor___EnumDescriptor = ...
             @classmethod
             def Name(cls, number: builtin___int) -> builtin___str: ...
             @classmethod
-            def Value(cls, name: builtin___str) -> 'AnotherNested.NestedMessage.NestedEnum2': ...
+            def Value(cls, name: builtin___str) -> AnotherNested.NestedMessage.NestedEnum2Value: ...
             @classmethod
             def keys(cls) -> typing___List[builtin___str]: ...
             @classmethod
-            def values(cls) -> typing___List['AnotherNested.NestedMessage.NestedEnum2']: ...
+            def values(cls) -> typing___List[AnotherNested.NestedMessage.NestedEnum2Value]: ...
             @classmethod
-            def items(cls) -> typing___List[typing___Tuple[builtin___str, 'AnotherNested.NestedMessage.NestedEnum2']]: ...
-            UNDEFINED = typing___cast('AnotherNested.NestedMessage.NestedEnum2', 0)
-            NESTED_ENUM1 = typing___cast('AnotherNested.NestedMessage.NestedEnum2', 1)
-            NESTED_ENUM2 = typing___cast('AnotherNested.NestedMessage.NestedEnum2', 2)
-        UNDEFINED = typing___cast('AnotherNested.NestedMessage.NestedEnum2', 0)
-        NESTED_ENUM1 = typing___cast('AnotherNested.NestedMessage.NestedEnum2', 1)
-        NESTED_ENUM2 = typing___cast('AnotherNested.NestedMessage.NestedEnum2', 2)
+            def items(cls) -> typing___List[typing___Tuple[builtin___str, AnotherNested.NestedMessage.NestedEnum2Value]]: ...
+            UNDEFINED = typing___cast(AnotherNested.NestedMessage.NestedEnum2Value, 0)
+            NESTED_ENUM1 = typing___cast(AnotherNested.NestedMessage.NestedEnum2Value, 1)
+            NESTED_ENUM2 = typing___cast(AnotherNested.NestedMessage.NestedEnum2Value, 2)
+        UNDEFINED = typing___cast(AnotherNested.NestedMessage.NestedEnum2Value, 0)
+        NESTED_ENUM1 = typing___cast(AnotherNested.NestedMessage.NestedEnum2Value, 1)
+        NESTED_ENUM2 = typing___cast(AnotherNested.NestedMessage.NestedEnum2Value, 2)
         global___NestedEnum2 = NestedEnum2
 
         s: typing___Text = ...
         b: builtin___bool = ...
-        ne: global___AnotherNested.NestedEnum = ...
-        ne2: global___AnotherNested.NestedMessage.NestedEnum2 = ...
+        ne: global___AnotherNested.NestedEnumValue = ...
+        ne2: global___AnotherNested.NestedMessage.NestedEnum2Value = ...
 
         def __init__(self,
             *,
             s : typing___Optional[typing___Text] = None,
             b : typing___Optional[builtin___bool] = None,
-            ne : typing___Optional[global___AnotherNested.NestedEnum] = None,
-            ne2 : typing___Optional[global___AnotherNested.NestedMessage.NestedEnum2] = None,
+            ne : typing___Optional[global___AnotherNested.NestedEnumValue] = None,
+            ne2 : typing___Optional[global___AnotherNested.NestedMessage.NestedEnum2Value] = None,
             ) -> None: ...
         if sys.version_info >= (3,):
             @classmethod

--- a/test/proto/test3_pb2.pyi.expected
+++ b/test/proto/test3_pb2.pyi.expected
@@ -16,6 +16,7 @@ from google.protobuf.message import (
 from typing import (
     Iterable as typing___Iterable,
     List as typing___List,
+    NewType as typing___NewType,
     Optional as typing___Optional,
     Text as typing___Text,
     Tuple as typing___Tuple,
@@ -39,24 +40,26 @@ if sys.version_info < (3,):
     builtin___unicode = unicode
 
 
-class OuterEnum(builtin___int):
+OuterEnumValue = typing___NewType('OuterEnumValue', builtin___int)
+global___OuterEnumValue = OuterEnumValue
+class OuterEnum(object):
     DESCRIPTOR: google___protobuf___descriptor___EnumDescriptor = ...
     @classmethod
     def Name(cls, number: builtin___int) -> builtin___str: ...
     @classmethod
-    def Value(cls, name: builtin___str) -> 'OuterEnum': ...
+    def Value(cls, name: builtin___str) -> OuterEnumValue: ...
     @classmethod
     def keys(cls) -> typing___List[builtin___str]: ...
     @classmethod
-    def values(cls) -> typing___List['OuterEnum']: ...
+    def values(cls) -> typing___List[OuterEnumValue]: ...
     @classmethod
-    def items(cls) -> typing___List[typing___Tuple[builtin___str, 'OuterEnum']]: ...
-    UNKNOWN = typing___cast('OuterEnum', 0)
-    FOO3 = typing___cast('OuterEnum', 1)
-    BAR3 = typing___cast('OuterEnum', 2)
-UNKNOWN = typing___cast('OuterEnum', 0)
-FOO3 = typing___cast('OuterEnum', 1)
-BAR3 = typing___cast('OuterEnum', 2)
+    def items(cls) -> typing___List[typing___Tuple[builtin___str, OuterEnumValue]]: ...
+    UNKNOWN = typing___cast(OuterEnumValue, 0)
+    FOO3 = typing___cast(OuterEnumValue, 1)
+    BAR3 = typing___cast(OuterEnumValue, 2)
+UNKNOWN = typing___cast(OuterEnumValue, 0)
+FOO3 = typing___cast(OuterEnumValue, 1)
+BAR3 = typing___cast(OuterEnumValue, 2)
 global___OuterEnum = OuterEnum
 
 class OuterMessage3(google___protobuf___message___Message):
@@ -82,12 +85,12 @@ class SimpleProto3(google___protobuf___message___Message):
     DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
     a_string: typing___Text = ...
     a_repeated_string: google___protobuf___internal___containers___RepeatedScalarFieldContainer[typing___Text] = ...
-    a_outer_enum: global___OuterEnum = ...
+    a_outer_enum: global___OuterEnumValue = ...
     a_oneof_1: typing___Text = ...
     a_oneof_2: typing___Text = ...
     b_oneof_1: typing___Text = ...
     b_oneof_2: typing___Text = ...
-    OuterEnum: global___OuterEnum = ...
+    OuterEnum: global___OuterEnumValue = ...
 
     @property
     def outer_message(self) -> global___OuterMessage3: ...
@@ -102,14 +105,14 @@ class SimpleProto3(google___protobuf___message___Message):
         *,
         a_string : typing___Optional[typing___Text] = None,
         a_repeated_string : typing___Optional[typing___Iterable[typing___Text]] = None,
-        a_outer_enum : typing___Optional[global___OuterEnum] = None,
+        a_outer_enum : typing___Optional[global___OuterEnumValue] = None,
         outer_message : typing___Optional[global___OuterMessage3] = None,
         a_oneof_1 : typing___Optional[typing___Text] = None,
         a_oneof_2 : typing___Optional[typing___Text] = None,
         b_oneof_1 : typing___Optional[typing___Text] = None,
         b_oneof_2 : typing___Optional[typing___Text] = None,
         bool : typing___Optional[global___OuterMessage3] = None,
-        OuterEnum : typing___Optional[global___OuterEnum] = None,
+        OuterEnum : typing___Optional[global___OuterEnumValue] = None,
         OuterMessage3 : typing___Optional[global___OuterMessage3] = None,
         ) -> None: ...
     if sys.version_info >= (3,):

--- a/test/proto/test_pb2.pyi.expected
+++ b/test/proto/test_pb2.pyi.expected
@@ -43,13 +43,14 @@ from test.proto.nopackage_pb2 import (
 )
 
 from test.proto.test3_pb2 import (
-    OuterEnum as test___proto___test3_pb2___OuterEnum,
+    OuterEnumValue as test___proto___test3_pb2___OuterEnumValue,
 )
 
 from typing import (
     Callable as typing___Callable,
     Iterable as typing___Iterable,
     List as typing___List,
+    NewType as typing___NewType,
     Optional as typing___Optional,
     Text as typing___Text,
     Tuple as typing___Tuple,
@@ -72,42 +73,46 @@ if sys.version_info < (3,):
     builtin___unicode = unicode
 
 
-class OuterEnum(builtin___int):
+OuterEnumValue = typing___NewType('OuterEnumValue', builtin___int)
+global___OuterEnumValue = OuterEnumValue
+class OuterEnum(object):
     DESCRIPTOR: google___protobuf___descriptor___EnumDescriptor = ...
     @classmethod
     def Name(cls, number: builtin___int) -> builtin___str: ...
     @classmethod
-    def Value(cls, name: builtin___str) -> 'OuterEnum': ...
+    def Value(cls, name: builtin___str) -> OuterEnumValue: ...
     @classmethod
     def keys(cls) -> typing___List[builtin___str]: ...
     @classmethod
-    def values(cls) -> typing___List['OuterEnum']: ...
+    def values(cls) -> typing___List[OuterEnumValue]: ...
     @classmethod
-    def items(cls) -> typing___List[typing___Tuple[builtin___str, 'OuterEnum']]: ...
-    FOO = typing___cast('OuterEnum', 1)
-    BAR = typing___cast('OuterEnum', 2)
-FOO = typing___cast('OuterEnum', 1)
-BAR = typing___cast('OuterEnum', 2)
+    def items(cls) -> typing___List[typing___Tuple[builtin___str, OuterEnumValue]]: ...
+    FOO = typing___cast(OuterEnumValue, 1)
+    BAR = typing___cast(OuterEnumValue, 2)
+FOO = typing___cast(OuterEnumValue, 1)
+BAR = typing___cast(OuterEnumValue, 2)
 global___OuterEnum = OuterEnum
 
 class Simple1(google___protobuf___message___Message):
     DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
-    class InnerEnum(builtin___int):
+    InnerEnumValue = typing___NewType('InnerEnumValue', builtin___int)
+    global___InnerEnumValue = InnerEnumValue
+    class InnerEnum(object):
         DESCRIPTOR: google___protobuf___descriptor___EnumDescriptor = ...
         @classmethod
         def Name(cls, number: builtin___int) -> builtin___str: ...
         @classmethod
-        def Value(cls, name: builtin___str) -> 'Simple1.InnerEnum': ...
+        def Value(cls, name: builtin___str) -> Simple1.InnerEnumValue: ...
         @classmethod
         def keys(cls) -> typing___List[builtin___str]: ...
         @classmethod
-        def values(cls) -> typing___List['Simple1.InnerEnum']: ...
+        def values(cls) -> typing___List[Simple1.InnerEnumValue]: ...
         @classmethod
-        def items(cls) -> typing___List[typing___Tuple[builtin___str, 'Simple1.InnerEnum']]: ...
-        INNER1 = typing___cast('Simple1.InnerEnum', 1)
-        INNER2 = typing___cast('Simple1.InnerEnum', 2)
-    INNER1 = typing___cast('Simple1.InnerEnum', 1)
-    INNER2 = typing___cast('Simple1.InnerEnum', 2)
+        def items(cls) -> typing___List[typing___Tuple[builtin___str, Simple1.InnerEnumValue]]: ...
+        INNER1 = typing___cast(Simple1.InnerEnumValue, 1)
+        INNER2 = typing___cast(Simple1.InnerEnumValue, 2)
+    INNER1 = typing___cast(Simple1.InnerEnumValue, 1)
+    INNER2 = typing___cast(Simple1.InnerEnumValue, 2)
     global___InnerEnum = InnerEnum
 
     class InnerMessage(google___protobuf___message___Message):
@@ -129,11 +134,11 @@ class Simple1(google___protobuf___message___Message):
     a_repeated_string: google___protobuf___internal___containers___RepeatedScalarFieldContainer[typing___Text] = ...
     a_boolean: builtin___bool = ...
     a_uint32: builtin___int = ...
-    a_enum: global___OuterEnum = ...
-    a_external_enum: test___proto___test3_pb2___OuterEnum = ...
-    inner_enum: global___Simple1.InnerEnum = ...
-    rep_inner_enum: google___protobuf___internal___containers___RepeatedScalarFieldContainer[global___Simple1.InnerEnum] = ...
-    nested_enum: test___proto___nested___nested_pb2___AnotherNested.NestedEnum = ...
+    a_enum: global___OuterEnumValue = ...
+    a_external_enum: test___proto___test3_pb2___OuterEnumValue = ...
+    inner_enum: global___Simple1.InnerEnumValue = ...
+    rep_inner_enum: google___protobuf___internal___containers___RepeatedScalarFieldContainer[global___Simple1.InnerEnumValue] = ...
+    nested_enum: test___proto___nested___nested_pb2___AnotherNested.NestedEnumValue = ...
     a_oneof_1: typing___Text = ...
     a_oneof_2: typing___Text = ...
 
@@ -161,16 +166,16 @@ class Simple1(google___protobuf___message___Message):
         a_repeated_string : typing___Optional[typing___Iterable[typing___Text]] = None,
         a_boolean : typing___Optional[builtin___bool] = None,
         a_uint32 : typing___Optional[builtin___int] = None,
-        a_enum : typing___Optional[global___OuterEnum] = None,
-        a_external_enum : typing___Optional[test___proto___test3_pb2___OuterEnum] = None,
+        a_enum : typing___Optional[global___OuterEnumValue] = None,
+        a_external_enum : typing___Optional[test___proto___test3_pb2___OuterEnumValue] = None,
         a_inner : typing___Optional[test___proto___inner___inner_pb2___Inner] = None,
         a_nested : typing___Optional[test___proto___nested___nested_pb2___Nested] = None,
-        inner_enum : typing___Optional[global___Simple1.InnerEnum] = None,
-        rep_inner_enum : typing___Optional[typing___Iterable[global___Simple1.InnerEnum]] = None,
+        inner_enum : typing___Optional[global___Simple1.InnerEnumValue] = None,
+        rep_inner_enum : typing___Optional[typing___Iterable[global___Simple1.InnerEnumValue]] = None,
         inner_message : typing___Optional[global___Simple1.InnerMessage] = None,
         rep_inner_message : typing___Optional[typing___Iterable[global___Simple1.InnerMessage]] = None,
         no_package : typing___Optional[test___proto___nopackage_pb2___NoPackage] = None,
-        nested_enum : typing___Optional[test___proto___nested___nested_pb2___AnotherNested.NestedEnum] = None,
+        nested_enum : typing___Optional[test___proto___nested___nested_pb2___AnotherNested.NestedEnumValue] = None,
         nested_message : typing___Optional[test___proto___nested___nested_pb2___AnotherNested.NestedMessage] = None,
         a_oneof_1 : typing___Optional[typing___Text] = None,
         a_oneof_2 : typing___Optional[typing___Text] = None,

--- a/test/test_generated_mypy.py
+++ b/test/test_generated_mypy.py
@@ -63,7 +63,7 @@ def test_generate_mypy_matches():
             open(expected, "w").write(output_contents)
             failures.append(
                 (
-                    "%s doesn't match %s. This test will copy it over."
+                    "%s doesn't match %s. This test will copy it over. Please rerun"
                     % (output, expected)
                 )
             )
@@ -99,8 +99,8 @@ def test_generate_negative_matches():
     assert errors_35 == expected_errors_35
 
     # Some sanity checks to make sure we don't mess this up. Please update as necessary.
-    assert len(errors_27) == 24
-    assert len(errors_35) == 24
+    assert len(errors_27) == 25
+    assert len(errors_35) == 25
 
 
 def test_func():

--- a/test_negative/negative.py
+++ b/test_negative/negative.py
@@ -11,7 +11,7 @@ from typing import (
 )
 
 from test.proto.test_pb2 import FOO, Simple1, Simple2
-from test.proto.test3_pb2 import OuterEnum, SimpleProto3
+from test.proto.test3_pb2 import OuterEnum, OuterEnumValue, SimpleProto3
 from test.proto.dot.com.test_pb2 import TestMessage
 
 s = Simple1()
@@ -78,3 +78,9 @@ SimpleProto3().DESCRIPTOR.Garbage()  # E:2.7 E:3.5
 # Enum DESCRIPTOR should detect invalid access:
 OuterEnum.DESCRIPTOR.Garbage()  # E:2.7 E:3.5
 
+# Enum value type should be an EnumValueType convertible to int
+enum = OuterEnumValue(5)
+enum = s6.a_outer_enum
+as_int = 5
+as_int = s6.a_outer_enum
+s6.a_outer_enum.FOO  # E:2.7 E:3.5

--- a/test_negative/output.expected.2.7
+++ b/test_negative/output.expected.2.7
@@ -3,7 +3,7 @@ test_negative/negative.py:23: error: Argument 1 to "ParseFromString" of "Message
 test_negative/negative.py:26: error: Argument 1 to "CopyFrom" of "Simple1" has incompatible type "str"; expected "Message"
 test_negative/negative.py:30: error: Argument 1 to "extend" of "list" has incompatible type "RepeatedScalarFieldContainer[unicode]"; expected "Iterable[int]"
 test_negative/negative.py:32: error: Argument "foo" to "TestMessage" has incompatible type "int"; expected "Optional[unicode]"
-test_negative/negative.py:35: error: Incompatible types in assignment (expression has type "int", variable has type "OuterEnum")
+test_negative/negative.py:35: error: Incompatible types in assignment (expression has type "int", variable has type "OuterEnumValue")
 test_negative/negative.py:38: error: Argument 1 to "HasField" of "Simple1" has incompatible type "Literal['garbage']"; expected <union: 30 items>
 test_negative/negative.py:39: error: Argument 1 to "HasField" of "Simple1" has incompatible type "Literal['a_repeated_string']"; expected <union: 30 items>
 test_negative/negative.py:43: error: Argument 1 to "HasField" of "SimpleProto3" has incompatible type "Literal[u'garbage']"; expected <union: 18 items>
@@ -25,4 +25,5 @@ test_negative/negative.py:72: error: Incompatible types in assignment (expressio
 test_negative/negative.py:75: error: "Descriptor" has no attribute "Garbage"
 test_negative/negative.py:76: error: "Descriptor" has no attribute "Garbage"
 test_negative/negative.py:79: error: "EnumDescriptor" has no attribute "Garbage"
-Found 24 errors in 1 file (checked 3 source files)
+test_negative/negative.py:86: error: "OuterEnumValue" has no attribute "FOO"
+Found 25 errors in 1 file (checked 3 source files)

--- a/test_negative/output.expected.3.5
+++ b/test_negative/output.expected.3.5
@@ -3,7 +3,7 @@ test_negative/negative.py:23: error: Argument 1 to "ParseFromString" of "Message
 test_negative/negative.py:26: error: Argument 1 to "CopyFrom" of "Simple1" has incompatible type "bytes"; expected "Message"
 test_negative/negative.py:30: error: Argument 1 to "extend" of "list" has incompatible type "RepeatedScalarFieldContainer[str]"; expected "Iterable[int]"
 test_negative/negative.py:32: error: Argument "foo" to "TestMessage" has incompatible type "int"; expected "Optional[str]"
-test_negative/negative.py:35: error: Incompatible types in assignment (expression has type "int", variable has type "OuterEnum")
+test_negative/negative.py:35: error: Incompatible types in assignment (expression has type "int", variable has type "OuterEnumValue")
 test_negative/negative.py:38: error: Argument 1 to "HasField" of "Simple1" has incompatible type "Literal['garbage']"; expected <union: 30 items>
 test_negative/negative.py:39: error: Argument 1 to "HasField" of "Simple1" has incompatible type "Literal['a_repeated_string']"; expected <union: 30 items>
 test_negative/negative.py:43: error: Argument 1 to "HasField" of "SimpleProto3" has incompatible type "Literal['garbage']"; expected <union: 18 items>
@@ -25,4 +25,5 @@ test_negative/negative.py:72: error: Incompatible types in assignment (expressio
 test_negative/negative.py:75: error: "Descriptor" has no attribute "Garbage"
 test_negative/negative.py:76: error: "Descriptor" has no attribute "Garbage"
 test_negative/negative.py:79: error: "EnumDescriptor" has no attribute "Garbage"
-Found 24 errors in 1 file (checked 3 source files)
+test_negative/negative.py:86: error: "OuterEnumValue" has no attribute "FOO"
+Found 25 errors in 1 file (checked 3 source files)


### PR DESCRIPTION
This fixes the conflation of the value type from the EnumTypeWrapper in the typing.

Added tests to confirm that we correctly error if used incorrectly.

Fixes #118