### PR TITLE
rename `_EnumTypeWrapper` to `EnumTypeWrapper`

### DIFF
--- a/python/mypy_protobuf.py
+++ b/python/mypy_protobuf.py
@@ -230,7 +230,7 @@ class PkgWriter(object):
                 "class {}({}[{}]):",
                 "_" + enum.name,
                 self._import(
-                    "google.protobuf.internal.enum_type_wrapper", "_EnumTypeWrapper"
+                    "google.protobuf.internal.enum_type_wrapper", "EnumTypeWrapper"
                 ),
                 enum_value_full_type,
             )


### PR DESCRIPTION
The module `google.protobuf.internal.enum_type_wrapper` does not contain the generated object `_EnumTypeWrapper`.

According to the history of google's [protobuf repository](https://github.com/protocolbuffers/protobuf) (master/v4/v3/v2.6.1) the fixed name has been used for the past few years.
Hence I feel safe to make this a simple fix, without consideration in the protobuf compiler/module installed.