### PR TITLE
Split CI matrix based on python version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,30 +5,70 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run_test:
-    name: Test on python ${{ matrix.python-version }}
+    name: ${{ matrix.py-ver-mypy-protobuf }} / ${{matrix.py-ver-mypy-target}} / ${{matrix.py-ver-unit-tests}} protoc/mypytarget/unittests py versions
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        # Running mypy-protobuf itself
+        # py-ver-mypy-protobuf: []
+        # --python-version=X target passed into mypy
+        # py-ver-mypy-target: []
+        # Run unit tests - validating that correct typechecking usages
+        # of the google.protobuf library in various python versions
+        # also run at runtime
+        # py-ver-unit-tests: []
+
+        # Explicitly list out each part of the matrix we're using, rather
+        # than automatically multiplying the set in together, so we don't
+        # over-test combinations unnecessarily.
+        include:
+          # Include 3.5, 2.7 for the mypy-target
+          - py-ver-mypy-protobuf: 3.8.6
+            py-ver-mypy-target: 3.5
+            py-ver-unit-tests: 3.8.6
+          - py-ver-mypy-protobuf: 3.8.6
+            py-ver-mypy-target: 2.7
+            py-ver-unit-tests: 3.8.6
+
+          # Include py 2.7, 3.6 - 3.8 for mypy-protobuf runtime
+          - py-ver-mypy-protobuf: 3.6.12
+            py-ver-mypy-target: 3.5
+            py-ver-unit-tests: 3.8.6
+          - py-ver-mypy-protobuf: 3.7.9
+            py-ver-mypy-target: 3.5
+            py-ver-unit-tests: 3.8.6
+          - py-ver-mypy-protobuf: 2.7.18
+            py-ver-mypy-target: 3.5
+            py-ver-unit-tests: 3.8.6
+
+          # Include python runtime of google.protobuf in 2.7
+          - py-ver-mypy-protobuf: 3.8.6
+            py-ver-mypy-target: 3.5
+            py-ver-unit-tests: 2.7.18
     steps:
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
-          version: '3.13.0'
+          version: '3.14.0'
       - uses: actions/checkout@v2
-      - name: Set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - name: Install pyenv
+        uses: gabrielfalcao/pyenv-action@v7
         with:
-          python-version: ${{ matrix.python-version }}
+          # Ideally - we could specify only the versions we need, but blocked
+          # on https://github.com/gabrielfalcao/pyenv-action/issues/135
+          # versions: ${{matrix.py-ver-mypy-protobuf}}, ${{matrix.py-ver-unit-tests}}, 3.8.6
+          versions: 3.7.9, 3.6.12, 2.7.18
+          default: 3.8.6
+          command: python -m pip install virtualenv
       - name: Run Tests (./run_test.sh)
-        run: |
-          python --version
-          python -m pip install virtualenv
-          python3 -m pip install virtualenv
-          ./run_test.sh
+        env:
+          PY_VER_MYPY_PROTOBUF: ${{matrix.py-ver-mypy-protobuf}}
+          PY_VER_MYPY_TARGET: ${{matrix.py-ver-mypy-target}}
+          PY_VER_UNIT_TESTS: ${{matrix.py-ver-unit-tests}}
+        run: ./run_test.sh
 
   black:
-    name: Check formatting with black
+    name: Black formatting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-protobuf==3.13.0
+protobuf==3.14.0
 six
-pytest
-typing
+pytest == 4.6.11
+typing ; python_version<"3.5"
 
 # For python2. See https://github.com/pypa/virtualenv/issues/1493
-setuptools<45.0.0
+setuptools<45.0.0 ; python_version < '3.0'
+setuptools ; python_version >= '3.0'

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,17 +1,23 @@
 #!/bin/bash -ex
 
-PY_VERSION=`python -c 'import sys; print(sys.version.split()[0])'`
-VENV=venv_$PY_VERSION
-MYPY_VENV=venv_mypy
-
 RED="\033[0;31m"
 NC='\033[0m'
 PROTOC=${PROTOC:=protoc}
+
+PY_VER_MYPY_PROTOBUF=${PY_VER_MYPY_PROTOBUF:=3.8.6}
+PY_VER_MYPY=${PY_VER_MYPY:=3.8.6}
+PY_VER_MYPY_TARGET=${PY_VER_MYPY_TARGET:=3.5}
+PY_VER_UNIT_TESTS=${PY_VER_UNIT_TESTS:=3.8.6}
 
 # Clean out generated/ directory - except for .generated / __init__.py
 find generated -type f -not \( -name "*.expected" -or -name "__init__.py" \) -delete
 
 (
+    eval "$(pyenv init -)"
+    pyenv shell $PY_VER_MYPY_PROTOBUF
+    PY_VERSION=`python -c 'import sys; print(sys.version.split()[0])'`
+    VENV=venv_$PY_VERSION
+
     # Create virtualenv + Install requirements for mypy-protobuf
     if [[ -z $SKIP_CLEAN ]] || [[ ! -e $VENV ]]; then
         python -m virtualenv $VENV
@@ -22,7 +28,7 @@ find generated -type f -not \( -name "*.expected" -or -name "__init__.py" \) -de
     # Generate protos
     python --version
     $PROTOC --version
-    expected="libprotoc 3.13.0"
+    expected="libprotoc 3.14.0"
     if [[ $($PROTOC --version) != $expected ]]; then
         echo -e "${RED}For tests - must install protoc version ${expected} ${NC}"
         exit 1
@@ -32,36 +38,46 @@ find generated -type f -not \( -name "*.expected" -or -name "__init__.py" \) -de
 )
 
 (
-    # Run mypy (always under python3)
+    # Run mypy
+    eval "$(pyenv init -)"
+    pyenv shell $PY_VER_MYPY
+    PY_VERSION=`python -c 'import sys; print(sys.version.split()[0])'`
+    VENV=venv_$PY_VERSION
 
     # Create virtualenv
-    if [[ -z $SKIP_CLEAN ]] || [[ ! -e $MYPY_VENV ]]; then
+    if [[ -z $SKIP_CLEAN ]] || [[ ! -e $VENV ]]; then
         python3 --version
         python3 -m pip --version
-        python3 -m virtualenv $MYPY_VENV
+        python3 -m virtualenv $VENV
     fi
-    source $MYPY_VENV/bin/activate
-    if [[ -z $SKIP_CLEAN ]] || [[ ! -e $MYPY_VENV ]]; then
+    source $VENV/bin/activate
+    if [[ -z $SKIP_CLEAN ]] || [[ ! -e $VENV ]]; then
         python3 -m pip install setuptools
         python3 -m pip install git+https://github.com/python/mypy.git@985a20d87eb3a516ff4457041a77026b4c6bd784
     fi
 
     # Run mypy
-    for PY in 2.7 3.5; do
-        mypy --custom-typeshed-dir=$CUSTOM_TYPESHED_DIR --python-version=$PY --pretty --show-error-codes python/mypy_protobuf.py test/ generated/
-        if ! diff <(mypy --custom-typeshed-dir=$CUSTOM_TYPESHED_DIR --python-version=$PY python/mypy_protobuf.py test_negative/ generated/) test_negative/output.expected.$PY; then
-            echo -e "${RED}test_negative/output.expected.$PY didnt match. Copying over for you. Now rerun${NC}"
-            for PY in 2.7 3.5; do
-                mypy --custom-typeshed-dir=$CUSTOM_TYPESHED_DIR --python-version=$PY python/mypy_protobuf.py test_negative/ generated/ > test_negative/output.expected.$PY || true
-            done
-            exit 1
-        fi
-    done
+    mypy --custom-typeshed-dir=$CUSTOM_TYPESHED_DIR --python-version=$PY_VER_MYPY_TARGET --pretty --show-error-codes python/mypy_protobuf.py test/ generated/
+    if ! diff <(mypy --custom-typeshed-dir=$CUSTOM_TYPESHED_DIR --python-version=$PY_VER_MYPY_TARGET python/mypy_protobuf.py test_negative/ generated/) test_negative/output.expected.$PY_VER_MYPY_TARGET; then
+        echo -e "${RED}test_negative/output.expected.$PY_VER_MYPY_TARGET didnt match. Copying over for you. Now rerun${NC}"
+        mypy --custom-typeshed-dir=$CUSTOM_TYPESHED_DIR --python-version=$PY_VER_MYPY_TARGET python/mypy_protobuf.py test_negative/ generated/ > test_negative/output.expected.$PY_VER_MYPY_TARGET || true
+        exit 1
+    fi
 )
 
 (
     # Run unit tests. These tests generate .expected files
+    eval "$(pyenv init -)"
+    pyenv shell $PY_VER_UNIT_TESTS
+    PY_VERSION=`python -c 'import sys; print(sys.version.split()[0])'`
+    VENV=venv_$PY_VERSION
+
+    if [[ -z $SKIP_CLEAN ]] || [[ ! -e $VENV ]]; then
+        python -m virtualenv $VENV
+    fi
     source $VENV/bin/activate
+    python -m pip install -r requirements.txt
+
     python --version
     py.test --version
     PYTHONPATH=generated py.test --ignore=generated


### PR DESCRIPTION
Want to test running
mypy protobuf: 3.8, 3.7, 3.6, 2.7 [looking to drop 2.7 here]
mypy target: 2.7, 3.5 [looking to expand in future]
unit tests: 2.7, 3.8  [Validating real runtime behavior of google.protobuf]

Chose 6 key matrix plans to cover these cases (instead of full 3x2x2 matrix)

In the future, hope to split out the mypy of mypy_protobuf.py itself
into a separate step - which only targets supported mypy protobuf versions,
allowing us to drop 2.7 as a mypy_protobuf runtime and simplify futher