### PR TITLE
Drop support for running mypy_protobuf in python2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,11 +22,6 @@ jobs:
         # than automatically multiplying the set in together, so we don't
         # over-test combinations unnecessarily.
         include:
-          # Include a full 2.7 run
-          - py-ver-mypy-protobuf: 2.7.18
-            py-ver-mypy-target: 2.7
-            py-ver-unit-tests: 2.7.18
-
           # Include a python3 compile with mypy targeting 2.7 code
           - py-ver-mypy-protobuf: 3.8.6
             py-ver-mypy-target: 2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Upcoming
 
 Non Backward Compatible Changes
+- Dropping support for running mypy-protobuf in python2. Note you can still generate stubs target-compatible to python2
 - Type proto Enum values for as `MyEnum.V` rather than `MyEnumValue` for import ergonomics,
 allowing the caller to import `MyEnum` rather than conditionally importing `MyEnumValue`
 - Rename extensions proto from `mypy/mypy.proto` to `mypy_protobuf/extensions.proto`

--- a/python/mypy_protobuf_lib.py
+++ b/python/mypy_protobuf_lib.py
@@ -102,8 +102,7 @@ def _forward_ref(name):
 # field names.
 
 
-def _mangle_message(name):
-    # type: (Text) -> Text
+def _mangle_message(name: Text) -> Text:
     """Enum variant `Name` might conflict with a message or enum named `Name`, so
     mangle it with a type__ prefix for internal references"""
     return "type___{}".format(name)

--- a/run_test.sh
+++ b/run_test.sh
@@ -45,13 +45,9 @@ find generated -type f -not \( -name "*.expected" -or -name "__init__.py" \) -de
     $PROTOC $PROTOC_ARGS --mypy_out=generated `find proto -name "*.proto"`
 
     # Compile GRPC
-    if [[ $PY_VER_MYPY_PROTOBUF =~ ^3.* ]]; then
-        GRPC_PROTOS=$(find proto/testproto/grpc -name "*.proto")
-        $PROTOC $PROTOC_ARGS --mypy_grpc_out=generated $GRPC_PROTOS
-        python -m grpc_tools.protoc $PROTOC_ARGS --grpc_python_out=generated $GRPC_PROTOS
-    fi
-
-
+    GRPC_PROTOS=$(find proto/testproto/grpc -name "*.proto")
+    $PROTOC $PROTOC_ARGS --mypy_grpc_out=generated $GRPC_PROTOS
+    python -m grpc_tools.protoc $PROTOC_ARGS --grpc_python_out=generated $GRPC_PROTOS
 )
 
 (
@@ -77,7 +73,7 @@ find generated -type f -not \( -name "*.expected" -or -name "__init__.py" \) -de
     # Run mypy
     mypy --version
     # --python-version=2.7 chokes on the generated grpc files - so split them out here
-    FILES27="python/mypy_protobuf_lib.py $(find test -name "*.py" | grep -v grpc)  $(find generated -name "*.pyi" | grep -v grpc)"
+    FILES27="$(find test -name "*.py" | grep -v grpc)  $(find generated -name "*.pyi" | grep -v grpc)"
     FILES35="python/mypy_protobuf_lib.py test/ generated/"
     if [ $PY_VER_MYPY_TARGET = "2.7" ]; then
         FILES=$FILES27

--- a/test_negative/output.expected.2.7
+++ b/test_negative/output.expected.2.7
@@ -64,4 +64,4 @@ test_negative/negative.py:156: error: Argument "user_id" to "Simple1" has incomp
 test_negative/negative.py:156: error: Argument "email" to "Simple1" has incompatible type "str"; expected "Optional[Email]"
 test_negative/negative.py:156: error: Dict entry 0 has incompatible type "int": "str"; expected "UserId": "Email"
 test_negative/negative.py:159: error: Module 'testproto.reexport_pb2' has no attribute 'Inner'
-Found 53 errors in 1 file (checked 18 source files)
+Found 53 errors in 1 file (checked 17 source files)


### PR DESCRIPTION
Note that you can still generate stubs that target python2 - and
this scenario is still tested in our CI