### PR TITLE
Add test asserting types for EnumTypeWrapper.Value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Upcoming
 
 - Fix CI caching across version updates.
+- Added unit testing for EnumTypeWrapper.Value usage
 
 ## 2.2
 

--- a/test/test_generated_mypy.py
+++ b/test/test_generated_mypy.py
@@ -188,6 +188,10 @@ def test_enum():
     e4 = OuterEnum.Value("BAR")  # type: int
     assert OuterEnum.Name(e2) == "BAR"
 
+    # Protobuf itself allows both unicode and bytes here.
+    # TODO - typeshed currently has a bug where it only allows str
+    assert OuterEnum.Value(u"BAR") == OuterEnum.Value(b"BAR")  # type: ignore[arg-type]
+
 
 def test_has_field_proto2():
     # type: () -> None


### PR DESCRIPTION
Discovered a typeshed bug where EnumTypeWrapper.Value only accepts
str, when (across py2 and py3), it should accept unicode and bytes