### PR TITLE
Ordered enum classes  to work better with Pyright

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Upcoming
 
-- Changed type generation for `grpcio` stubs to use the `MultiCallable` API ([see here](https://grpc.github.io/grpc/python/grpc.html#multi-callable-interfaces)) . This requires using the `grpc-stubs` typings for grpcio. This change should allow calling stub methods with common parameters (`timeout`, `metadata`, etc.) as well as calling methods on the `MultiCallable` object (e.g. `my_stub.MyRpcMethod.future()`). 
+- Organized generated enum code to prevent definition ordering issues in Pyright-based linters
+- Changed type generation for `grpcio` stubs to use the `MultiCallable` API ([see here](https://grpc.github.io/grpc/python/grpc.html#multi-callable-interfaces)) . This requires using the `grpc-stubs` typings for grpcio. This change should allow calling stub methods with common parameters (`timeout`, `metadata`, etc.) as well as calling methods on the `MultiCallable` object (e.g. `my_stub.MyRpcMethod.future()`).
 
 ## 2.4
 

--- a/mypy_protobuf/main.py
+++ b/mypy_protobuf/main.py
@@ -239,8 +239,14 @@ class PkgWriter(object):
                     self._import("typing", "NewType"),
                     self._builtin("int"),
                 )
+            l("")
             if prefix == "" and not self.readable_stubs:
                 l("{} = {}", _mangle_global_identifier(enum.name), enum.name)
+                l("")
+                
+            self.write_enum_values(enum, prefix + enum.name + ".V")
+            l("")
+            
             l(
                 "class {}({}[{}], {}):",
                 "_" + enum.name,
@@ -256,9 +262,8 @@ class PkgWriter(object):
                     self._import("google.protobuf.descriptor", "EnumDescriptor"),
                 )
                 self.write_enum_values(enum, prefix + enum.name + ".V")
-
-            self.write_enum_values(enum, prefix + enum.name + ".V")
             l("")
+
 
     def write_messages(
         self, messages: Iterable[d.DescriptorProto], prefix: str

--- a/mypy_protobuf/main.py
+++ b/mypy_protobuf/main.py
@@ -243,10 +243,10 @@ class PkgWriter(object):
             if prefix == "" and not self.readable_stubs:
                 l("{} = {}", _mangle_global_identifier(enum.name), enum.name)
                 l("")
-                
+
             self.write_enum_values(enum, prefix + enum.name + ".V")
             l("")
-            
+
             l(
                 "class {}({}[{}], {}):",
                 "_" + enum.name,
@@ -263,7 +263,6 @@ class PkgWriter(object):
                 )
                 self.write_enum_values(enum, prefix + enum.name + ".V")
             l("")
-
 
     def write_messages(
         self, messages: Iterable[d.DescriptorProto], prefix: str

--- a/mypy_protobuf/main.py
+++ b/mypy_protobuf/main.py
@@ -232,6 +232,13 @@ class PkgWriter(object):
     ) -> None:
         l = self._write_line
         for enum in [e for e in enums if e.name not in PYTHON_RESERVED]:
+            l("class {}(metaclass={}):", enum.name, "_" + enum.name)
+            with self._indent():
+                l(
+                    "V = {}('V', {})",
+                    self._import("typing", "NewType"),
+                    self._builtin("int"),
+                )
             if prefix == "" and not self.readable_stubs:
                 l("{} = {}", _mangle_global_identifier(enum.name), enum.name)
             l(
@@ -249,14 +256,6 @@ class PkgWriter(object):
                     self._import("google.protobuf.descriptor", "EnumDescriptor"),
                 )
                 self.write_enum_values(enum, prefix + enum.name + ".V")
-
-            l("class {}(metaclass={}):", enum.name, "_" + enum.name)
-            with self._indent():
-                l(
-                    "V = {}('V', {})",
-                    self._import("typing", "NewType"),
-                    self._builtin("int"),
-                )
 
             self.write_enum_values(enum, prefix + enum.name + ".V")
             l("")

--- a/test/generated/testproto/nested/nested_pb2.pyi.expected
+++ b/test/generated/testproto/nested/nested_pb2.pyi.expected
@@ -28,27 +28,31 @@ class AnotherNested(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     class NestedEnum(metaclass=_NestedEnum):
         V = typing.NewType('V', builtins.int)
+
+    INVALID = AnotherNested.NestedEnum.V(0)
+    ONE = AnotherNested.NestedEnum.V(1)
+    TWO = AnotherNested.NestedEnum.V(2)
+
     class _NestedEnum(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[NestedEnum.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
         INVALID = AnotherNested.NestedEnum.V(0)
         ONE = AnotherNested.NestedEnum.V(1)
         TWO = AnotherNested.NestedEnum.V(2)
-    INVALID = AnotherNested.NestedEnum.V(0)
-    ONE = AnotherNested.NestedEnum.V(1)
-    TWO = AnotherNested.NestedEnum.V(2)
 
     class NestedMessage(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
         class NestedEnum2(metaclass=_NestedEnum2):
             V = typing.NewType('V', builtins.int)
+
+        UNDEFINED = AnotherNested.NestedMessage.NestedEnum2.V(0)
+        NESTED_ENUM1 = AnotherNested.NestedMessage.NestedEnum2.V(1)
+        NESTED_ENUM2 = AnotherNested.NestedMessage.NestedEnum2.V(2)
+
         class _NestedEnum2(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[NestedEnum2.V], builtins.type):
             DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
             UNDEFINED = AnotherNested.NestedMessage.NestedEnum2.V(0)
             NESTED_ENUM1 = AnotherNested.NestedMessage.NestedEnum2.V(1)
             NESTED_ENUM2 = AnotherNested.NestedMessage.NestedEnum2.V(2)
-        UNDEFINED = AnotherNested.NestedMessage.NestedEnum2.V(0)
-        NESTED_ENUM1 = AnotherNested.NestedMessage.NestedEnum2.V(1)
-        NESTED_ENUM2 = AnotherNested.NestedMessage.NestedEnum2.V(2)
 
         S_FIELD_NUMBER: builtins.int
         B_FIELD_NUMBER: builtins.int

--- a/test/generated/testproto/nested/nested_pb2.pyi.expected
+++ b/test/generated/testproto/nested/nested_pb2.pyi.expected
@@ -26,26 +26,26 @@ global___Nested = Nested
 
 class AnotherNested(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
+    class NestedEnum(metaclass=_NestedEnum):
+        V = typing.NewType('V', builtins.int)
     class _NestedEnum(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[NestedEnum.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
         INVALID = AnotherNested.NestedEnum.V(0)
         ONE = AnotherNested.NestedEnum.V(1)
         TWO = AnotherNested.NestedEnum.V(2)
-    class NestedEnum(metaclass=_NestedEnum):
-        V = typing.NewType('V', builtins.int)
     INVALID = AnotherNested.NestedEnum.V(0)
     ONE = AnotherNested.NestedEnum.V(1)
     TWO = AnotherNested.NestedEnum.V(2)
 
     class NestedMessage(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
+        class NestedEnum2(metaclass=_NestedEnum2):
+            V = typing.NewType('V', builtins.int)
         class _NestedEnum2(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[NestedEnum2.V], builtins.type):
             DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
             UNDEFINED = AnotherNested.NestedMessage.NestedEnum2.V(0)
             NESTED_ENUM1 = AnotherNested.NestedMessage.NestedEnum2.V(1)
             NESTED_ENUM2 = AnotherNested.NestedMessage.NestedEnum2.V(2)
-        class NestedEnum2(metaclass=_NestedEnum2):
-            V = typing.NewType('V', builtins.int)
         UNDEFINED = AnotherNested.NestedMessage.NestedEnum2.V(0)
         NESTED_ENUM1 = AnotherNested.NestedMessage.NestedEnum2.V(1)
         NESTED_ENUM2 = AnotherNested.NestedMessage.NestedEnum2.V(2)

--- a/test/generated/testproto/test3_pb2.pyi.expected
+++ b/test/generated/testproto/test3_pb2.pyi.expected
@@ -14,15 +14,18 @@ DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
 class OuterEnum(metaclass=_OuterEnum):
     V = typing.NewType('V', builtins.int)
+
 global___OuterEnum = OuterEnum
+
+UNKNOWN = OuterEnum.V(0)
+FOO3 = OuterEnum.V(1)
+BAR3 = OuterEnum.V(2)
+
 class _OuterEnum(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[OuterEnum.V], builtins.type):
     DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
     UNKNOWN = OuterEnum.V(0)
     FOO3 = OuterEnum.V(1)
     BAR3 = OuterEnum.V(2)
-UNKNOWN = OuterEnum.V(0)
-FOO3 = OuterEnum.V(1)
-BAR3 = OuterEnum.V(2)
 
 class OuterMessage3(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
@@ -40,12 +43,14 @@ class SimpleProto3(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     class InnerEnum(metaclass=_InnerEnum):
         V = typing.NewType('V', builtins.int)
+
+    INNER1 = SimpleProto3.InnerEnum.V(0)
+    INNER2 = SimpleProto3.InnerEnum.V(1)
+
     class _InnerEnum(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[InnerEnum.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
         INNER1 = SimpleProto3.InnerEnum.V(0)
         INNER2 = SimpleProto3.InnerEnum.V(1)
-    INNER1 = SimpleProto3.InnerEnum.V(0)
-    INNER2 = SimpleProto3.InnerEnum.V(1)
 
     class MapScalarEntry(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...

--- a/test/generated/testproto/test3_pb2.pyi.expected
+++ b/test/generated/testproto/test3_pb2.pyi.expected
@@ -12,14 +12,14 @@ import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
+class OuterEnum(metaclass=_OuterEnum):
+    V = typing.NewType('V', builtins.int)
 global___OuterEnum = OuterEnum
 class _OuterEnum(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[OuterEnum.V], builtins.type):
     DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
     UNKNOWN = OuterEnum.V(0)
     FOO3 = OuterEnum.V(1)
     BAR3 = OuterEnum.V(2)
-class OuterEnum(metaclass=_OuterEnum):
-    V = typing.NewType('V', builtins.int)
 UNKNOWN = OuterEnum.V(0)
 FOO3 = OuterEnum.V(1)
 BAR3 = OuterEnum.V(2)
@@ -38,12 +38,12 @@ global___OuterMessage3 = OuterMessage3
 
 class SimpleProto3(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
+    class InnerEnum(metaclass=_InnerEnum):
+        V = typing.NewType('V', builtins.int)
     class _InnerEnum(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[InnerEnum.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
         INNER1 = SimpleProto3.InnerEnum.V(0)
         INNER2 = SimpleProto3.InnerEnum.V(1)
-    class InnerEnum(metaclass=_InnerEnum):
-        V = typing.NewType('V', builtins.int)
     INNER1 = SimpleProto3.InnerEnum.V(0)
     INNER2 = SimpleProto3.InnerEnum.V(1)
 

--- a/test/generated/testproto/test_pb2.pyi.expected
+++ b/test/generated/testproto/test_pb2.pyi.expected
@@ -21,24 +21,24 @@ import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
+class OuterEnum(metaclass=_OuterEnum):
+    V = typing.NewType('V', builtins.int)
 global___OuterEnum = OuterEnum
 class _OuterEnum(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[OuterEnum.V], builtins.type):
     DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
     FOO = OuterEnum.V(1)
     BAR = OuterEnum.V(2)
-class OuterEnum(metaclass=_OuterEnum):
-    V = typing.NewType('V', builtins.int)
 FOO = OuterEnum.V(1)
 BAR = OuterEnum.V(2)
 
 class Simple1(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
+    class InnerEnum(metaclass=_InnerEnum):
+        V = typing.NewType('V', builtins.int)
     class _InnerEnum(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[InnerEnum.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
         INNER1 = Simple1.InnerEnum.V(1)
         INNER2 = Simple1.InnerEnum.V(2)
-    class InnerEnum(metaclass=_InnerEnum):
-        V = typing.NewType('V', builtins.int)
     INNER1 = Simple1.InnerEnum.V(1)
     INNER2 = Simple1.InnerEnum.V(2)
 

--- a/test/generated/testproto/test_pb2.pyi.expected
+++ b/test/generated/testproto/test_pb2.pyi.expected
@@ -23,24 +23,29 @@ DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
 class OuterEnum(metaclass=_OuterEnum):
     V = typing.NewType('V', builtins.int)
+
 global___OuterEnum = OuterEnum
+
+FOO = OuterEnum.V(1)
+BAR = OuterEnum.V(2)
+
 class _OuterEnum(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[OuterEnum.V], builtins.type):
     DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
     FOO = OuterEnum.V(1)
     BAR = OuterEnum.V(2)
-FOO = OuterEnum.V(1)
-BAR = OuterEnum.V(2)
 
 class Simple1(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     class InnerEnum(metaclass=_InnerEnum):
         V = typing.NewType('V', builtins.int)
+
+    INNER1 = Simple1.InnerEnum.V(1)
+    INNER2 = Simple1.InnerEnum.V(2)
+
     class _InnerEnum(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[InnerEnum.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
         INNER1 = Simple1.InnerEnum.V(1)
         INNER2 = Simple1.InnerEnum.V(2)
-    INNER1 = Simple1.InnerEnum.V(1)
-    INNER2 = Simple1.InnerEnum.V(2)
 
     class InnerMessage(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...


### PR DESCRIPTION
The order that enums are currently generated leads to an undeclared type being used for both the mangling reference and the field references. This might not be an issue in mypy, but in Pyright, it causes the linter to not be able to recognize the source type for these fields:

![image](https://user-images.githubusercontent.com/4652122/108299415-65027a80-716c-11eb-8fa3-fb64229f30eb.png)


I've simply switched around the declaration to this: 
![image](https://user-images.githubusercontent.com/4652122/108302632-5a4ae400-7172-11eb-8226-6c9255327a8b.png)

Outside of giving the members a little more room to breathe, it reduces the declaration order issue.

However, there is still the unknown type in the generic EnumTypeWrapper. I think I will investigate that in the pyright repo (since I assume it works with mypy)

