### PR TITLE
Fix generated code for enums with  name conflict with EnumTypeWrapper…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ test_message_option: google.protobuf.descriptor.FieldDescriptor = ...
 test_message_option: google.protobuf.internal.extension_dict._ExtensionFieldDescriptor[google.protobuf.descriptor_pb2.MessageOptions, typing.Text] = ...
 ```
 - Now requires [types-protobuf](https://pypi.org/project/types-protobuf/) 3.17.1
+- Fix [#238](https://github.com/dropbox/mypy-protobuf/issues/238) - handling enum variants that name conflict with EnumTypeWrapper methods
 
 
 ## 2.6

--- a/proto/testproto/test.proto
+++ b/proto/testproto/test.proto
@@ -13,6 +13,18 @@ enum OuterEnum {
   BAR = 2;
 }
 
+enum NamingConflicts {
+  // Naming conflicts!
+  Name = 1;
+  Value = 2;
+  keys = 3;
+  values = 4;
+  items = 5;
+  // See https://github.com/protocolbuffers/protobuf/issues/8803
+  // proto itself generates broken code when DESCRIPTOR is there
+  // DESCRIPTOR = 8;
+}
+
 message Simple1 {
   enum InnerEnum {
     INNER1 = 1;

--- a/test/generated/testproto/test_pb2.pyi.expected
+++ b/test/generated/testproto/test_pb2.pyi.expected
@@ -34,6 +34,20 @@ class _OuterEnum(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[Out
     FOO = OuterEnum.V(1)
     BAR = OuterEnum.V(2)
 
+class NamingConflicts(metaclass=_NamingConflicts):
+    V = typing.NewType('V', builtins.int)
+
+global___NamingConflicts = NamingConflicts
+
+Name = NamingConflicts.V(1)
+Value = NamingConflicts.V(2)
+keys = NamingConflicts.V(3)
+values = NamingConflicts.V(4)
+items = NamingConflicts.V(5)
+
+class _NamingConflicts(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[NamingConflicts.V], builtins.type):  # type: ignore
+    DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
+
 class Simple1(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     class InnerEnum(metaclass=_InnerEnum):

--- a/test/test_generated_mypy.py
+++ b/test/test_generated_mypy.py
@@ -31,6 +31,8 @@ from testproto.test_pb2 import (
     Extensions1,
     Extensions2,
     FOO,
+    Name as NamingConflicts_Name,
+    NamingConflicts,
     OuterEnum,
     Simple1,
     Simple2,
@@ -200,6 +202,13 @@ def test_enum():
 
     # Protobuf itself allows both unicode and bytes here.
     assert OuterEnum.Value(u"BAR") == OuterEnum.Value(b"BAR")
+
+
+def test_enum_naming_conflicts():
+    # type: () -> None
+    assert NamingConflicts.Name(NamingConflicts_Name) == "Name"
+    assert NamingConflicts.Value("Name") == 1
+    assert NamingConflicts_Name == 1
 
 
 def test_has_field_proto2():


### PR DESCRIPTION
… fields

For example, the following has a field which conflicts
with a method on the EnumTypeWrapper class.
```
enum {
  Name = 1;
}
```

Fixes #238