### PR TITLE
Remove the windows .bat file - and add windows to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,3 +96,19 @@ jobs:
         run: |
           pip3 install black
           black --check mypy_protobuf/main.py test/
+
+  sanity_check_windows:
+    name: Sanity Check Windows Executable
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: '3.17.3'
+      - name: Run Protoc
+        run: |
+          pip3 install -e .
+          mkdir wintestout
+          protoc --python_out=wintestout --mypy_out=wintestout proto\mypy_protobuf\extensions.proto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add protobuf type stubs to the setup requirements
 - Fix [#239](https://github.com/dropbox/mypy-protobuf/issues/239) Remove type: ignore used in enum by pulling `V` into a separate class.
 - Use pytest 6.2.4 for internal test suites on python3
+- Remove `protoc_gen_mypy.bat` as the entry-points method creates protoc-gen-mypy.exe. Add test confirming.
 
 ## 2.7
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Alternately, you can explicitly provide the path:
 ```
 protoc --plugin=protoc-gen-mypy=path/to/protoc-gen-mypy --python_out=output/location --mypy_out=output/location
 ```
-On windows, provide the bat file:
+Check the version number with
 ```
-protoc --plugin=protoc-gen-mypy=path/to/protoc_gen_mypy.bat --python_out=output/location --mypy_out=output/location
+> protoc-gen-mypy --version
 ```
 
 ## Getting Help
@@ -68,7 +68,7 @@ Find other developers in the mypy-protobuf slack workspace ([Invitation Link](ht
 ## Implementation
 
 The implementation of the plugin is in `mypy_protobuf/main.py`, which installs to
-an executable protoc-gen-mypy. On windows you will have to use `protoc_gen_mypy.bat` for the executable.
+an executable protoc-gen-mypy. On windows it installs to `protoc-gen-mypy.exe`
 
 ## Features
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,5 @@ setup(
             "protoc-gen-mypy_grpc = mypy_protobuf.main:grpc",
         ],
     },
-    scripts=["mypy_protobuf/protoc_gen_mypy.bat"],
     python_requires=">=3.6",
 )


### PR DESCRIPTION
Bat file is no longer needed as the entrypoints method creates protoc-gen-mypy.exe

Fixes #215
Fixes #261