### PR TITLE
Remove dependency on grpcio-tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Upcoming
 
 - Switch from setup.py to pyproject.toml and setup.cfg per https://packaging.python.org/tutorials/packaging-projects/
+- Remove dependency on grpcio-tools. mypy-protobuf doesn't need it to run. It's only needed to run mypy afterward.
 
 ## 2.9
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ py_modules =
 install_requires =
     protobuf>=3.17.3
     types-protobuf>=3.17.3
-    grpcio-tools>=1.38.1
 python_requires = >=3.6
 
 [options.entry_points]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,8 +1,9 @@
 # Requirements to run unit tests. Tests import from
 # generated code.
+protobuf>=3.17.3
 pytest ; python_version < "3.0"
 pytest==6.2.4 ; python_version >= "3.0"
-protobuf>=3.17.3
-typing ; python_version<"3.5"
 grpc-stubs>=1.24.6 ; python_version>="3.0"
+grpcio-tools>=1.38.1 ; python_version >= "3.5"
 types-protobuf==3.17.3
+typing ; python_version<"3.5"


### PR DESCRIPTION
mypy-protobuf doesn't require it to run. It's only required to
run mypy on the generated stubs. This removes a dependency, especially
nice for folks not actually using grpc.

Fixes #270