### PR TITLE
Disambiguate reserved keywords with "_r_" rather than "__"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Remove dependency on grpcio-tools. mypy-protobuf doesn't need it to run. It's only needed to run mypy afterward.
 - Avoid relative imports in `_grpc_pb2.pyi` stubs. grpc stubs themselves don't use relative imports, nor `__init__.py` files
 - Use `"""` docstring style comments in generated code rather than `#` style so it shows up in IDEs.
+- Disambiguate messages from reserved python keywords (eg `None`) with prefix `_r_` rather than `__` - since `__` is considered private.
 - Since upstream protobuf has dropped support with 3.18.0, 2.10 will be the last mypy-protobuf that supports targeting python 2.7. Updated docs for this.
 
 ## 2.9

--- a/mypy_protobuf/main.py
+++ b/mypy_protobuf/main.py
@@ -193,11 +193,11 @@ class PkgWriter(object):
             assert name.startswith(".")
             name = name[1:]
 
-        # Use prepended "__" to disambiguate message names that alias python reserved keywords
+        # Use prepended "_r_" to disambiguate message names that alias python reserved keywords
         split = name.split(".")
         for i, part in enumerate(split):
             if part in PYTHON_RESERVED:
-                split[i] = "__" + part
+                split[i] = "_r_" + part
         name = ".".join(split)
 
         # Message defined in this file. Note: GRPC stubs in same .proto are generated into separate files
@@ -318,7 +318,7 @@ class PkgWriter(object):
         l = self._write_line
         for i, enum in enumerate(enums):
             class_name = (
-                enum.name if enum.name not in PYTHON_RESERVED else "__" + enum.name
+                enum.name if enum.name not in PYTHON_RESERVED else "_r_" + enum.name
             )
             value_type_fq = prefix + class_name + ".V"
 
@@ -399,7 +399,7 @@ class PkgWriter(object):
                 )
 
             class_name = (
-                desc.name if desc.name not in PYTHON_RESERVED else "__" + desc.name
+                desc.name if desc.name not in PYTHON_RESERVED else "_r_" + desc.name
             )
             message_class = self._import("google.protobuf.message", "Message")
             l("class {}({}{}):", class_name, message_class, addl_base)
@@ -648,7 +648,7 @@ class PkgWriter(object):
             class_name = (
                 service.name
                 if service.name not in PYTHON_RESERVED
-                else "__" + service.name
+                else "_r_" + service.name
             )
             # The service definition interface
             l(

--- a/test/generated/testproto/test_pb2.pyi
+++ b/test/generated/testproto/test_pb2.pyi
@@ -237,7 +237,7 @@ class Extensions2(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"flag",b"flag"]) -> None: ...
 global___Extensions2 = Extensions2
 
-class __None(google.protobuf.message.Message):
+class _r_None(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     VALID_FIELD_NUMBER: builtins.int
     valid: builtins.int = ...
@@ -247,21 +247,21 @@ class __None(google.protobuf.message.Message):
         ) -> None: ...
     def HasField(self, field_name: typing_extensions.Literal[u"valid",b"valid"]) -> builtins.bool: ...
     def ClearField(self, field_name: typing_extensions.Literal[u"valid",b"valid"]) -> None: ...
-global_____None = __None
+global____r_None = _r_None
 
 class PythonReservedKeywords(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
-    class __finally(_finally, metaclass=_finallyEnumTypeWrapper):
+    class _r_finally(_finally, metaclass=_finallyEnumTypeWrapper):
         pass
     class _finally:
         V = typing.NewType('V', builtins.int)
     class _finallyEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_finally.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
-        valid_in_finally = PythonReservedKeywords.__finally.V(2)
+        valid_in_finally = PythonReservedKeywords._r_finally.V(2)
 
-    valid_in_finally = PythonReservedKeywords.__finally.V(2)
+    valid_in_finally = PythonReservedKeywords._r_finally.V(2)
 
-    class __lambda(google.protobuf.message.Message):
+    class _r_lambda(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
         CONTINUE_FIELD_NUMBER: builtins.int
         VALID_FIELD_NUMBER: builtins.int
@@ -304,14 +304,14 @@ class PythonReservedKeywords(google.protobuf.message.Message):
     NONE_FIELD_NUMBER: builtins.int
     VALID_FIELD_NUMBER: builtins.int
     @property
-    def none(self) -> global_____None:
+    def none(self) -> global____r_None:
         """Test unreserved identifiers w/ reserved message names"""
         pass
-    valid: global___PythonReservedKeywords.__finally.V = ...
+    valid: global___PythonReservedKeywords._r_finally.V = ...
     def __init__(self,
         *,
-        none : typing.Optional[global_____None] = ...,
-        valid : typing.Optional[global___PythonReservedKeywords.__finally.V] = ...,
+        none : typing.Optional[global____r_None] = ...,
+        valid : typing.Optional[global___PythonReservedKeywords._r_finally.V] = ...,
         ) -> None: ...
     def HasField(self, field_name: typing_extensions.Literal[u"False",b"False",u"True",b"True",u"and",b"and",u"as",b"as",u"assert",b"assert",u"break",b"break",u"class",b"class",u"def",b"def",u"del",b"del",u"elif",b"elif",u"else",b"else",u"except",b"except",u"for",b"for",u"from",b"from",u"global",b"global",u"if",b"if",u"import",b"import",u"in",b"in",u"is",b"is",u"none",b"none",u"nonlocal",b"nonlocal",u"not",b"not",u"or",b"or",u"pass",b"pass",u"raise",b"raise",u"try",b"try",u"valid",b"valid",u"while",b"while",u"with",b"with",u"yield",b"yield"]) -> builtins.bool: ...
     def ClearField(self, field_name: typing_extensions.Literal[u"False",b"False",u"True",b"True",u"and",b"and",u"as",b"as",u"assert",b"assert",u"break",b"break",u"class",b"class",u"def",b"def",u"del",b"del",u"elif",b"elif",u"else",b"else",u"except",b"except",u"for",b"for",u"from",b"from",u"global",b"global",u"if",b"if",u"import",b"import",u"in",b"in",u"is",b"is",u"none",b"none",u"nonlocal",b"nonlocal",u"not",b"not",u"or",b"or",u"pass",b"pass",u"raise",b"raise",u"try",b"try",u"valid",b"valid",u"while",b"while",u"with",b"with",u"yield",b"yield"]) -> None: ...
@@ -347,16 +347,16 @@ class PythonReservedKeywordsService(google.protobuf.service.Service, metaclass=a
     def valid_method_name1(self,
         rpc_controller: google.protobuf.service.RpcController,
         request: global___Simple1,
-        done: typing.Optional[typing.Callable[[global_____None], None]],
-    ) -> concurrent.futures.Future[global_____None]:
+        done: typing.Optional[typing.Callable[[global____r_None], None]],
+    ) -> concurrent.futures.Future[global____r_None]:
         """valid_method_name1"""
         pass
     @abc.abstractmethod
     def valid_method_name2(self,
         rpc_controller: google.protobuf.service.RpcController,
         request: global___Simple1,
-        done: typing.Optional[typing.Callable[[global___PythonReservedKeywords.__lambda], None]],
-    ) -> concurrent.futures.Future[global___PythonReservedKeywords.__lambda]:
+        done: typing.Optional[typing.Callable[[global___PythonReservedKeywords._r_lambda], None]],
+    ) -> concurrent.futures.Future[global___PythonReservedKeywords._r_lambda]:
         """valid_method_name2"""
         pass
 class PythonReservedKeywordsService_Stub(PythonReservedKeywordsService):
@@ -365,15 +365,15 @@ class PythonReservedKeywordsService_Stub(PythonReservedKeywordsService):
     def valid_method_name1(self,
         rpc_controller: google.protobuf.service.RpcController,
         request: global___Simple1,
-        done: typing.Optional[typing.Callable[[global_____None], None]],
-    ) -> concurrent.futures.Future[global_____None]:
+        done: typing.Optional[typing.Callable[[global____r_None], None]],
+    ) -> concurrent.futures.Future[global____r_None]:
         """valid_method_name1"""
         pass
     def valid_method_name2(self,
         rpc_controller: google.protobuf.service.RpcController,
         request: global___Simple1,
-        done: typing.Optional[typing.Callable[[global___PythonReservedKeywords.__lambda], None]],
-    ) -> concurrent.futures.Future[global___PythonReservedKeywords.__lambda]:
+        done: typing.Optional[typing.Callable[[global___PythonReservedKeywords._r_lambda], None]],
+    ) -> concurrent.futures.Future[global___PythonReservedKeywords._r_lambda]:
         """valid_method_name2"""
         pass
 class ATestService(google.protobuf.service.Service, metaclass=abc.ABCMeta):

--- a/test/test_generated_mypy.py
+++ b/test/test_generated_mypy.py
@@ -538,7 +538,7 @@ def test_reserved_keywords():
         getattr(test_pb2, "asdf")
 
     # Confirm that "None" is a Message
-    none_cls = getattr(test_pb2, "None")  # type: Type[test_pb2.__None]
+    none_cls = getattr(test_pb2, "None")  # type: Type[test_pb2._r_None]
     none_instance = none_cls(valid=5)
     assert isinstance(none_instance, Message)
 

--- a/test_negative/output.expected.2.7
+++ b/test_negative/output.expected.2.7
@@ -70,6 +70,6 @@ test_negative/negative.py:165: error: Module "testproto.reexport_pb2" has no att
 test_negative/negative.py:169: error: Argument "a_string" to "OuterMessage3" has incompatible type "None"; expected "unicode"  [arg-type]
 test_negative/negative.py:174: error: Property "a_repeated_string" defined in "Simple1" is read-only  [misc]
 test_negative/negative.py:175: error: Property "rep_inner_enum" defined in "Simple1" is read-only  [misc]
-test_negative/negative.py:180: error: "__None" has no attribute "invalid"; maybe "valid"?  [attr-defined]
+test_negative/negative.py:180: error: "_r_None" has no attribute "invalid"; maybe "valid"?  [attr-defined]
 test_negative/negative.py:184: error: Incompatible types in assignment (expression has type "V", variable has type "str")  [assignment]
 Found 64 errors in 1 file (checked 17 source files)

--- a/test_negative/output.expected.2.7.omit_linenos
+++ b/test_negative/output.expected.2.7.omit_linenos
@@ -70,6 +70,6 @@ test_negative/negative.py: error: Module "testproto.reexport_pb2" has no attribu
 test_negative/negative.py: error: Argument "a_string" to "OuterMessage3" has incompatible type "None"; expected "unicode"  [arg-type]
 test_negative/negative.py: error: Property "a_repeated_string" defined in "Simple1" is read-only  [misc]
 test_negative/negative.py: error: Property "rep_inner_enum" defined in "Simple1" is read-only  [misc]
-test_negative/negative.py: error: "__None" has no attribute "invalid"; maybe "valid"?  [attr-defined]
+test_negative/negative.py: error: "_r_None" has no attribute "invalid"; maybe "valid"?  [attr-defined]
 test_negative/negative.py: error: Incompatible types in assignment (expression has type "V", variable has type "str")  [assignment]
 Found 64 errors in 1 file (checked 17 source files)

--- a/test_negative/output.expected.3.8
+++ b/test_negative/output.expected.3.8
@@ -92,6 +92,6 @@ test_negative/negative.py:165: error: Module "testproto.reexport_pb2" has no att
 test_negative/negative.py:169: error: Argument "a_string" to "OuterMessage3" has incompatible type "None"; expected "str"  [arg-type]
 test_negative/negative.py:174: error: Property "a_repeated_string" defined in "Simple1" is read-only  [misc]
 test_negative/negative.py:175: error: Property "rep_inner_enum" defined in "Simple1" is read-only  [misc]
-test_negative/negative.py:180: error: "__None" has no attribute "invalid"; maybe "valid"?  [attr-defined]
+test_negative/negative.py:180: error: "_r_None" has no attribute "invalid"; maybe "valid"?  [attr-defined]
 test_negative/negative.py:184: error: Incompatible types in assignment (expression has type "V", variable has type "str")  [assignment]
 Found 80 errors in 2 files (checked 30 source files)

--- a/test_negative/output.expected.3.8.omit_linenos
+++ b/test_negative/output.expected.3.8.omit_linenos
@@ -92,6 +92,6 @@ test_negative/negative.py: error: Module "testproto.reexport_pb2" has no attribu
 test_negative/negative.py: error: Argument "a_string" to "OuterMessage3" has incompatible type "None"; expected "str"  [arg-type]
 test_negative/negative.py: error: Property "a_repeated_string" defined in "Simple1" is read-only  [misc]
 test_negative/negative.py: error: Property "rep_inner_enum" defined in "Simple1" is read-only  [misc]
-test_negative/negative.py: error: "__None" has no attribute "invalid"; maybe "valid"?  [attr-defined]
+test_negative/negative.py: error: "_r_None" has no attribute "invalid"; maybe "valid"?  [attr-defined]
 test_negative/negative.py: error: Incompatible types in assignment (expression has type "V", variable has type "str")  [assignment]
 Found 80 errors in 2 files (checked 30 source files)


### PR DESCRIPTION
"__" has a special meaning of private-not-exported in python.