### PR TITLE
Use regular strings for docstring comment (instead of raw string)

### DIFF
--- a/mypy_protobuf/extensions_pb2.pyi
+++ b/mypy_protobuf/extensions_pb2.pyi
@@ -10,10 +10,10 @@ import typing
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
 casttype: google.protobuf.internal.extension_dict._ExtensionFieldDescriptor[google.protobuf.descriptor_pb2.FieldOptions, typing.Text] = ...
-r"""Tells mypy to use a specific newtype rather than the normal type for this field."""
+"""Tells mypy to use a specific newtype rather than the normal type for this field."""
 
 keytype: google.protobuf.internal.extension_dict._ExtensionFieldDescriptor[google.protobuf.descriptor_pb2.FieldOptions, typing.Text] = ...
-r"""Tells mypy to use a specific type for keys; only makes sense on map fields"""
+"""Tells mypy to use a specific type for keys; only makes sense on map fields"""
 
 valuetype: google.protobuf.internal.extension_dict._ExtensionFieldDescriptor[google.protobuf.descriptor_pb2.FieldOptions, typing.Text] = ...
-r"""Tells mypy to use a specific type for values; only makes sense on map fields"""
+"""Tells mypy to use a specific type for values; only makes sense on map fields"""

--- a/mypy_protobuf/main.py
+++ b/mypy_protobuf/main.py
@@ -271,7 +271,7 @@ class PkgWriter(object):
 
         lines = [
             # Escape triple-quotes that would otherwise end the docstring early.
-            line.replace('"""', r"\"\"\"")
+            line.replace("\\", "\\\\").replace('"""', r"\"\"\"")
             for line in lines
         ]
         if len(lines) == 1:
@@ -282,11 +282,11 @@ class PkgWriter(object):
                 # This is not necessary with multiline comments
                 # because in that case we always insert a newline before the trailing triple-quotes.
                 line = line + " "
-            self._write_line('r"""{}"""', line)
+            self._write_line('"""{}"""', line)
         else:
             for i, line in enumerate(lines):
                 if i == 0:
-                    self._write_line('r"""{}', line)
+                    self._write_line('"""{}', line)
                 else:
                     self._write_line("{}", line)
             self._write_line('"""')

--- a/test/generated/google/protobuf/duration_pb2.pyi
+++ b/test/generated/google/protobuf/duration_pb2.pyi
@@ -11,7 +11,7 @@ import typing_extensions
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
 class Duration(google.protobuf.message.Message, google.protobuf.internal.well_known_types.Duration):
-    r"""A Duration represents a signed, fixed-length span of time represented
+    """A Duration represents a signed, fixed-length span of time represented
     as a count of seconds and fractions of seconds at nanosecond
     resolution. It is independent of any calendar and concepts like "day"
     or "month". It is related to Timestamp in that the difference between
@@ -74,13 +74,13 @@ class Duration(google.protobuf.message.Message, google.protobuf.internal.well_kn
     SECONDS_FIELD_NUMBER: builtins.int
     NANOS_FIELD_NUMBER: builtins.int
     seconds: builtins.int = ...
-    r"""Signed seconds of the span of time. Must be from -315,576,000,000
+    """Signed seconds of the span of time. Must be from -315,576,000,000
     to +315,576,000,000 inclusive. Note: these bounds are computed from:
     60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
     """
 
     nanos: builtins.int = ...
-    r"""Signed fractions of a second at nanosecond resolution of the span
+    """Signed fractions of a second at nanosecond resolution of the span
     of time. Durations less than one second are represented with a 0
     `seconds` field and a positive or negative `nanos` field. For durations
     of one second or more, a non-zero value for the `nanos` field must be

--- a/test/generated/mypy_protobuf/extensions_pb2.pyi
+++ b/test/generated/mypy_protobuf/extensions_pb2.pyi
@@ -10,10 +10,10 @@ import typing
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
 casttype: google.protobuf.internal.extension_dict._ExtensionFieldDescriptor[google.protobuf.descriptor_pb2.FieldOptions, typing.Text] = ...
-r"""Tells mypy to use a specific newtype rather than the normal type for this field."""
+"""Tells mypy to use a specific newtype rather than the normal type for this field."""
 
 keytype: google.protobuf.internal.extension_dict._ExtensionFieldDescriptor[google.protobuf.descriptor_pb2.FieldOptions, typing.Text] = ...
-r"""Tells mypy to use a specific type for keys; only makes sense on map fields"""
+"""Tells mypy to use a specific type for keys; only makes sense on map fields"""
 
 valuetype: google.protobuf.internal.extension_dict._ExtensionFieldDescriptor[google.protobuf.descriptor_pb2.FieldOptions, typing.Text] = ...
-r"""Tells mypy to use a specific type for values; only makes sense on map fields"""
+"""Tells mypy to use a specific type for values; only makes sense on map fields"""

--- a/test/generated/testproto/comment_special_chars_pb2.pyi
+++ b/test/generated/testproto/comment_special_chars_pb2.pyi
@@ -24,39 +24,39 @@ class Test(google.protobuf.message.Message):
     J_FIELD_NUMBER: builtins.int
     K_FIELD_NUMBER: builtins.int
     a: typing.Text = ...
-    r"""Ending with " """
+    """Ending with " """
 
     b: typing.Text = ...
-    r"""Ending with "" """
+    """Ending with "" """
 
     c: typing.Text = ...
-    r"""Ending with \"\"\" """
+    """Ending with \"\"\" """
 
     d: typing.Text = ...
-    r"""Ending with \ """
+    """Ending with \\ """
 
     e: typing.Text = ...
-    r"""Containing bad escape: \x"""
+    """Containing bad escape: \\x"""
 
     f: typing.Text = ...
-    r"""Containing \"\"\"" quadruple"""
+    """Containing \"\"\"" quadruple"""
 
     g: typing.Text = ...
-    r"""Containing \"\"\""" quintuple"""
+    """Containing \"\"\""" quintuple"""
 
     h: typing.Text = ...
-    r"""Containing \"\"\"\"\"\" sextuple"""
+    """Containing \"\"\"\"\"\" sextuple"""
 
     i: typing.Text = ...
-    r"""\"\"\" Multiple \"\"\" triples \"\"\" """
+    """\"\"\" Multiple \"\"\" triples \"\"\" """
 
     j: typing.Text = ...
-    r""""quotes" can be a problem in comments.
+    """"quotes" can be a problem in comments.
     \"\"\"Triple quotes\"\"\" just as well
     """
 
     k: typing.Text = ...
-    r"""\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"
+    """\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"
     "                                              "
     " Super Duper comments with surrounding edges! "
     "                                              "

--- a/test/generated/testproto/grpc/dummy_pb2_grpc.pyi
+++ b/test/generated/testproto/grpc/dummy_pb2_grpc.pyi
@@ -8,37 +8,37 @@ import testproto.grpc.dummy_pb2
 import typing
 
 class DummyServiceStub:
-    r"""DummyService"""
+    """DummyService"""
     def __init__(self, channel: grpc.Channel) -> None: ...
     UnaryUnary: grpc.UnaryUnaryMultiCallable[
         testproto.grpc.dummy_pb2.DummyRequest,
         testproto.grpc.dummy_pb2.DummyReply] = ...
-    r"""UnaryUnary"""
+    """UnaryUnary"""
 
     UnaryStream: grpc.UnaryStreamMultiCallable[
         testproto.grpc.dummy_pb2.DummyRequest,
         testproto.grpc.dummy_pb2.DummyReply] = ...
-    r"""UnaryStream"""
+    """UnaryStream"""
 
     StreamUnary: grpc.StreamUnaryMultiCallable[
         testproto.grpc.dummy_pb2.DummyRequest,
         testproto.grpc.dummy_pb2.DummyReply] = ...
-    r"""StreamUnary"""
+    """StreamUnary"""
 
     StreamStream: grpc.StreamStreamMultiCallable[
         testproto.grpc.dummy_pb2.DummyRequest,
         testproto.grpc.dummy_pb2.DummyReply] = ...
-    r"""StreamStream"""
+    """StreamStream"""
 
 
 class DummyServiceServicer(metaclass=abc.ABCMeta):
-    r"""DummyService"""
+    """DummyService"""
     @abc.abstractmethod
     def UnaryUnary(self,
         request: testproto.grpc.dummy_pb2.DummyRequest,
         context: grpc.ServicerContext,
     ) -> testproto.grpc.dummy_pb2.DummyReply:
-        r"""UnaryUnary"""
+        """UnaryUnary"""
         pass
 
     @abc.abstractmethod
@@ -46,7 +46,7 @@ class DummyServiceServicer(metaclass=abc.ABCMeta):
         request: testproto.grpc.dummy_pb2.DummyRequest,
         context: grpc.ServicerContext,
     ) -> typing.Iterator[testproto.grpc.dummy_pb2.DummyReply]:
-        r"""UnaryStream"""
+        """UnaryStream"""
         pass
 
     @abc.abstractmethod
@@ -54,7 +54,7 @@ class DummyServiceServicer(metaclass=abc.ABCMeta):
         request: typing.Iterator[testproto.grpc.dummy_pb2.DummyRequest],
         context: grpc.ServicerContext,
     ) -> testproto.grpc.dummy_pb2.DummyReply:
-        r"""StreamUnary"""
+        """StreamUnary"""
         pass
 
     @abc.abstractmethod
@@ -62,7 +62,7 @@ class DummyServiceServicer(metaclass=abc.ABCMeta):
         request: typing.Iterator[testproto.grpc.dummy_pb2.DummyRequest],
         context: grpc.ServicerContext,
     ) -> typing.Iterator[testproto.grpc.dummy_pb2.DummyReply]:
-        r"""StreamStream"""
+        """StreamStream"""
         pass
 
 

--- a/test/generated/testproto/grpc/import_pb2_grpc.pyi
+++ b/test/generated/testproto/grpc/import_pb2_grpc.pyi
@@ -8,17 +8,17 @@ import grpc
 import testproto.test_pb2
 
 class SimpleServiceStub:
-    r"""SimpleService"""
+    """SimpleService"""
     def __init__(self, channel: grpc.Channel) -> None: ...
     UnaryUnary: grpc.UnaryUnaryMultiCallable[
         google.protobuf.empty_pb2.Empty,
         testproto.test_pb2.Simple1] = ...
-    r"""UnaryUnary"""
+    """UnaryUnary"""
 
     UnaryStream: grpc.UnaryUnaryMultiCallable[
         testproto.test_pb2.Simple1,
         google.protobuf.empty_pb2.Empty] = ...
-    r"""UnaryStream"""
+    """UnaryStream"""
 
     NoComment: grpc.UnaryUnaryMultiCallable[
         testproto.test_pb2.Simple1,
@@ -26,13 +26,13 @@ class SimpleServiceStub:
 
 
 class SimpleServiceServicer(metaclass=abc.ABCMeta):
-    r"""SimpleService"""
+    """SimpleService"""
     @abc.abstractmethod
     def UnaryUnary(self,
         request: google.protobuf.empty_pb2.Empty,
         context: grpc.ServicerContext,
     ) -> testproto.test_pb2.Simple1:
-        r"""UnaryUnary"""
+        """UnaryUnary"""
         pass
 
     @abc.abstractmethod
@@ -40,7 +40,7 @@ class SimpleServiceServicer(metaclass=abc.ABCMeta):
         request: testproto.test_pb2.Simple1,
         context: grpc.ServicerContext,
     ) -> google.protobuf.empty_pb2.Empty:
-        r"""UnaryStream"""
+        """UnaryStream"""
         pass
 
     @abc.abstractmethod

--- a/test/generated/testproto/nopackage_pb2.pyi
+++ b/test/generated/testproto/nopackage_pb2.pyi
@@ -12,7 +12,7 @@ import typing_extensions
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
 class NoPackage(google.protobuf.message.Message):
-    r"""Intentionally don't set a package - just to make sure we can handle it.
+    """Intentionally don't set a package - just to make sure we can handle it.
 
     """
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...

--- a/test/generated/testproto/test3_pb2.pyi
+++ b/test/generated/testproto/test3_pb2.pyi
@@ -117,13 +117,13 @@ class SimpleProto3(google.protobuf.message.Message):
     @property
     def bool(self) -> global___OuterMessage3: ...
     OuterEnum: global___OuterEnum.V = ...
-    r"""Test having fieldname match messagename"""
+    """Test having fieldname match messagename"""
 
     @property
     def OuterMessage3(self) -> global___OuterMessage3: ...
     @property
     def map_scalar(self) -> google.protobuf.internal.containers.ScalarMap[builtins.int, typing.Text]:
-        r"""Test generation of map"""
+        """Test generation of map"""
         pass
     @property
     def map_message(self) -> google.protobuf.internal.containers.MessageMap[builtins.int, global___OuterMessage3]: ...

--- a/test/generated/testproto/test_pb2.pyi
+++ b/test/generated/testproto/test_pb2.pyi
@@ -22,30 +22,30 @@ import typing_extensions
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
 class OuterEnum(_OuterEnum, metaclass=_OuterEnumEnumTypeWrapper):
-    r"""Outer Enum"""
+    """Outer Enum"""
     pass
 class _OuterEnum:
     V = typing.NewType('V', builtins.int)
 class _OuterEnumEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_OuterEnum.V], builtins.type):
     DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
     FOO = OuterEnum.V(1)
-    r"""FOO"""
+    """FOO"""
 
     BAR = OuterEnum.V(2)
-    r"""BAR"""
+    """BAR"""
 
 
 FOO = OuterEnum.V(1)
-r"""FOO"""
+"""FOO"""
 
 BAR = OuterEnum.V(2)
-r"""BAR"""
+"""BAR"""
 
 global___OuterEnum = OuterEnum
 
 
 class NamingConflicts(_NamingConflicts, metaclass=_NamingConflictsEnumTypeWrapper):
-    r"""Naming conflicts!"""
+    """Naming conflicts!"""
     pass
 class _NamingConflicts:
     V = typing.NewType('V', builtins.int)
@@ -57,7 +57,7 @@ Value = NamingConflicts.V(2)
 keys = NamingConflicts.V(3)
 values = NamingConflicts.V(4)
 items = NamingConflicts.V(5)
-r"""See https://github.com/protocolbuffers/protobuf/issues/8803
+"""See https://github.com/protocolbuffers/protobuf/issues/8803
 proto itself generates broken code when DESCRIPTOR is there
 DESCRIPTOR = 8;
 """
@@ -66,27 +66,27 @@ global___NamingConflicts = NamingConflicts
 
 
 class Simple1(google.protobuf.message.Message):
-    r"""Message with one of everything"""
+    """Message with one of everything"""
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     class InnerEnum(_InnerEnum, metaclass=_InnerEnumEnumTypeWrapper):
-        r"""Inner Enum"""
+        """Inner Enum"""
         pass
     class _InnerEnum:
         V = typing.NewType('V', builtins.int)
     class _InnerEnumEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_InnerEnum.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
         INNER1 = Simple1.InnerEnum.V(1)
-        r"""INNER1"""
+        """INNER1"""
 
         INNER2 = Simple1.InnerEnum.V(2)
-        r"""INNER2"""
+        """INNER2"""
 
 
     INNER1 = Simple1.InnerEnum.V(1)
-    r"""INNER1"""
+    """INNER1"""
 
     INNER2 = Simple1.InnerEnum.V(2)
-    r"""INNER2"""
+    """INNER2"""
 
 
     class InnerMessage(google.protobuf.message.Message):
@@ -212,7 +212,7 @@ class Extensions1(google.protobuf.message.Message):
     EXT1_STRING_FIELD_NUMBER: builtins.int
     ext1_string: typing.Text = ...
     ext: google.protobuf.internal.extension_dict._ExtensionFieldDescriptor[global___Simple1, global___Extensions1] = ...
-    r"""ext"""
+    """ext"""
 
     def __init__(self,
         *,
@@ -227,7 +227,7 @@ class Extensions2(google.protobuf.message.Message):
     FLAG_FIELD_NUMBER: builtins.int
     flag: builtins.bool = ...
     foo: google.protobuf.internal.extension_dict._ExtensionFieldDescriptor[global___Simple1, global___Extensions2] = ...
-    r"""foo"""
+    """foo"""
 
     def __init__(self,
         *,
@@ -305,7 +305,7 @@ class PythonReservedKeywords(google.protobuf.message.Message):
     VALID_FIELD_NUMBER: builtins.int
     @property
     def none(self) -> global____r_None:
-        r"""Test unreserved identifiers w/ reserved message names"""
+        """Test unreserved identifiers w/ reserved message names"""
         pass
     valid: global___PythonReservedKeywords._r_finally.V = ...
     def __init__(self,
@@ -318,7 +318,7 @@ class PythonReservedKeywords(google.protobuf.message.Message):
 global___PythonReservedKeywords = PythonReservedKeywords
 
 class PythonReservedKeywordsSmall(google.protobuf.message.Message):
-    r"""Do one with just one arg - to make sure it's syntactically correct"""
+    """Do one with just one arg - to make sure it's syntactically correct"""
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     FROM_FIELD_NUMBER: builtins.int
     def __init__(self,
@@ -331,7 +331,7 @@ class SelfField(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     SELF_FIELD_NUMBER: builtins.int
     self: builtins.int = ...
-    r"""Field self -> must generate an __init__ method w/ different name"""
+    """Field self -> must generate an __init__ method w/ different name"""
 
     def __init__(self_,
         *,
@@ -342,14 +342,14 @@ class SelfField(google.protobuf.message.Message):
 global___SelfField = SelfField
 
 class PythonReservedKeywordsService(google.protobuf.service.Service, metaclass=abc.ABCMeta):
-    r"""Method name is reserved"""
+    """Method name is reserved"""
     @abc.abstractmethod
     def valid_method_name1(self,
         rpc_controller: google.protobuf.service.RpcController,
         request: global___Simple1,
         done: typing.Optional[typing.Callable[[global____r_None], None]],
     ) -> concurrent.futures.Future[global____r_None]:
-        r"""valid_method_name1"""
+        """valid_method_name1"""
         pass
     @abc.abstractmethod
     def valid_method_name2(self,
@@ -357,24 +357,24 @@ class PythonReservedKeywordsService(google.protobuf.service.Service, metaclass=a
         request: global___Simple1,
         done: typing.Optional[typing.Callable[[global___PythonReservedKeywords._r_lambda], None]],
     ) -> concurrent.futures.Future[global___PythonReservedKeywords._r_lambda]:
-        r"""valid_method_name2"""
+        """valid_method_name2"""
         pass
 class PythonReservedKeywordsService_Stub(PythonReservedKeywordsService):
-    r"""Method name is reserved"""
+    """Method name is reserved"""
     def __init__(self, rpc_channel: google.protobuf.service.RpcChannel) -> None: ...
     def valid_method_name1(self,
         rpc_controller: google.protobuf.service.RpcController,
         request: global___Simple1,
         done: typing.Optional[typing.Callable[[global____r_None], None]],
     ) -> concurrent.futures.Future[global____r_None]:
-        r"""valid_method_name1"""
+        """valid_method_name1"""
         pass
     def valid_method_name2(self,
         rpc_controller: google.protobuf.service.RpcController,
         request: global___Simple1,
         done: typing.Optional[typing.Callable[[global___PythonReservedKeywords._r_lambda], None]],
     ) -> concurrent.futures.Future[global___PythonReservedKeywords._r_lambda]:
-        r"""valid_method_name2"""
+        """valid_method_name2"""
         pass
 class ATestService(google.protobuf.service.Service, metaclass=abc.ABCMeta):
     @abc.abstractmethod


### PR DESCRIPTION
Requires manually escaping backslashes in original comments.