### PR TITLE
Assert that we're using C++ impl

### DIFF
--- a/test/test_generated_mypy.py
+++ b/test/test_generated_mypy.py
@@ -14,6 +14,7 @@ import pytest
 import sys
 
 from google.protobuf.descriptor import FieldDescriptor
+from google.protobuf.internal import api_implementation  # type: ignore
 from google.protobuf.message import Message
 
 import testproto.test_pb2 as test_pb2
@@ -59,6 +60,10 @@ from typing import (
     Tuple,
     Type,
 )
+
+# Tests only work with C++ python API implementation
+# Pure python impl has different semantics which are untested
+assert api_implementation.Type() == "cpp"
 
 UserId = NewType("UserId", int)
 


### PR DESCRIPTION
The pure python impl has different semantics under which the tests don't pass.
Notably they have different semantics around handling of bytestrings vs strings as keys/args.