### PR TITLE
Reference the helper ValueType class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Upcoming
 
 - Remove unnecessary `...` in generated files.
+- Reorder/reference enum classes to avoid forward references.
 - Internal: Get tests to pass on pure-python protobuf impl (minor semantic differences)
 
 ## 3.1.0

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ will appear as docstrings in .pyi files. Useful in IDEs for showing completions 
 Enum int values produce stubs which wrap the int values in NewType
 ```proto
 enum MyEnum {
-  FOO = 0;
-  BAR = 1;
+  HELLO = 0;
+  WORLD = 1;
 }
 ```
 Will yield an [enum type wrapper](https://github.com/python/typeshed/blob/16ae4c61201cd8b96b8b22cdfb2ab9e89ba5bcf2/stubs/protobuf/google/protobuf/internal/enum_type_wrapper.pyi) whose methods type to `MyEnum.ValueType` (a `NewType(int)` rather than `int`.
@@ -101,7 +101,7 @@ In python >= 3.7
 # from __future__ import annotations  # Not needed with python>=3.10 or protobuf>=3.20.0
 def f(x: MyEnum.ValueType):
     print(x)
-f(MyEnum.Value("FOO"))
+f(MyEnum.Value("HELLO"))
 ```
 
 With protobuf <= 3.20.0, for usages of cast, the type of `x` must be quoted
@@ -114,9 +114,9 @@ cast('MyEnum.ValueType', x)
 Similarly, for type aliases with protobuf < 3.20.0, you must either quote the type or hide it behind `TYPE_CHECKING`
 ```python
 from typing import Tuple, TYPE_CHECKING
-FOO = Tuple['MyEnum.ValueType', 'MyEnum.ValueType']
+HELLO = Tuple['MyEnum.ValueType', 'MyEnum.ValueType']
 if TYPE_CHECKING:
-    FOO = Tuple[MyEnum.ValueType, MyEnum.ValueType]
+    HELLO = Tuple[MyEnum.ValueType, MyEnum.ValueType]
 ```
 
 #### Enum int impl details
@@ -124,17 +124,18 @@ if TYPE_CHECKING:
 mypy-protobuf  autogenerates an instance of the EnumTypeWrapper as follows.
 
 ```python
-class MyEnum(_MyEnum, metaclass=_MyEnumEnumTypeWrapper):
-    pass
 class _MyEnum:
     ValueType = typing.NewType('ValueType', builtins.int)
-    V = Union[ValueType]
+    V: typing_extensions.TypeAlias = ValueType
 class _MyEnumEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_MyEnum.ValueType], builtins.type):
-    DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
-    FOO = MyEnum.ValueType(0)
-    BAR = MyEnum.ValueType(1)
-FOO = MyEnum.ValueType(0)
-BAR = MyEnum.ValueType(1)
+    DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
+    HELLO: _MyEnum.ValueType  # 0
+    WORLD: _MyEnum.ValueType  # 1
+class MyEnum(_MyEnum, metaclass=_MyEnumEnumTypeWrapper):
+    pass
+
+HELLO: MyEnum.ValueType  # 0
+WORLD: MyEnum.ValueType  # 1
 ```
 
 `_MyEnumEnumTypeWrapper` extends the EnumTypeWrapper to take/return MyEnum.ValueType rather than int

--- a/mypy_protobuf/main.py
+++ b/mypy_protobuf/main.py
@@ -327,6 +327,7 @@ class PkgWriter(object):
             )
             value_type_fq = prefix + class_name + ".ValueType"
             enum_helper_class = "_" + enum.name
+            value_type_helper_fq = prefix + enum_helper_class + ".ValueType"
             etw_helper_class = "_" + enum.name + "EnumTypeWrapper"
             scl = scl_prefix + [i]
 
@@ -345,7 +346,7 @@ class PkgWriter(object):
                 self._import(
                     "google.protobuf.internal.enum_type_wrapper", "_EnumTypeWrapper"
                 ),
-                enum_helper_class + ".ValueType",
+                value_type_helper_fq,
                 self._builtin("type"),
             )
             with self._indent():
@@ -357,7 +358,7 @@ class PkgWriter(object):
                         for i, v in enumerate(enum.value)
                         if v.name not in PROTO_ENUM_RESERVED
                     ],
-                    value_type_fq,
+                    value_type_helper_fq,
                     scl + [d.EnumDescriptorProto.VALUE_FIELD_NUMBER],
                 )
             l(f"class {class_name}({enum_helper_class}, metaclass={etw_helper_class}):")

--- a/test/generated/testproto/nested/nested_pb2.pyi
+++ b/test/generated/testproto/nested/nested_pb2.pyi
@@ -28,11 +28,11 @@ class AnotherNested(google.protobuf.message.Message):
     class _NestedEnum:
         ValueType = typing.NewType('ValueType', builtins.int)
         V: typing_extensions.TypeAlias = ValueType
-    class _NestedEnumEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_NestedEnum.ValueType], builtins.type):
+    class _NestedEnumEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[AnotherNested._NestedEnum.ValueType], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
-        INVALID: AnotherNested.NestedEnum.ValueType  # 0
-        ONE: AnotherNested.NestedEnum.ValueType  # 1
-        TWO: AnotherNested.NestedEnum.ValueType  # 2
+        INVALID: AnotherNested._NestedEnum.ValueType  # 0
+        ONE: AnotherNested._NestedEnum.ValueType  # 1
+        TWO: AnotherNested._NestedEnum.ValueType  # 2
     class NestedEnum(_NestedEnum, metaclass=_NestedEnumEnumTypeWrapper):
         pass
 
@@ -45,11 +45,11 @@ class AnotherNested(google.protobuf.message.Message):
         class _NestedEnum2:
             ValueType = typing.NewType('ValueType', builtins.int)
             V: typing_extensions.TypeAlias = ValueType
-        class _NestedEnum2EnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_NestedEnum2.ValueType], builtins.type):
+        class _NestedEnum2EnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[AnotherNested.NestedMessage._NestedEnum2.ValueType], builtins.type):
             DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
-            UNDEFINED: AnotherNested.NestedMessage.NestedEnum2.ValueType  # 0
-            NESTED_ENUM1: AnotherNested.NestedMessage.NestedEnum2.ValueType  # 1
-            NESTED_ENUM2: AnotherNested.NestedMessage.NestedEnum2.ValueType  # 2
+            UNDEFINED: AnotherNested.NestedMessage._NestedEnum2.ValueType  # 0
+            NESTED_ENUM1: AnotherNested.NestedMessage._NestedEnum2.ValueType  # 1
+            NESTED_ENUM2: AnotherNested.NestedMessage._NestedEnum2.ValueType  # 2
         class NestedEnum2(_NestedEnum2, metaclass=_NestedEnum2EnumTypeWrapper):
             pass
 

--- a/test/generated/testproto/readme_enum_pb2.pyi
+++ b/test/generated/testproto/readme_enum_pb2.pyi
@@ -15,8 +15,8 @@ class _MyEnum:
     V: typing_extensions.TypeAlias = ValueType
 class _MyEnumEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_MyEnum.ValueType], builtins.type):
     DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
-    HELLO: MyEnum.ValueType  # 0
-    WORLD: MyEnum.ValueType  # 1
+    HELLO: _MyEnum.ValueType  # 0
+    WORLD: _MyEnum.ValueType  # 1
 class MyEnum(_MyEnum, metaclass=_MyEnumEnumTypeWrapper):
     pass
 

--- a/test/generated/testproto/test3_pb2.pyi
+++ b/test/generated/testproto/test3_pb2.pyi
@@ -17,9 +17,9 @@ class _OuterEnum:
     V: typing_extensions.TypeAlias = ValueType
 class _OuterEnumEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_OuterEnum.ValueType], builtins.type):
     DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
-    UNKNOWN: OuterEnum.ValueType  # 0
-    FOO3: OuterEnum.ValueType  # 1
-    BAR3: OuterEnum.ValueType  # 2
+    UNKNOWN: _OuterEnum.ValueType  # 0
+    FOO3: _OuterEnum.ValueType  # 1
+    BAR3: _OuterEnum.ValueType  # 2
 class OuterEnum(_OuterEnum, metaclass=_OuterEnumEnumTypeWrapper):
     pass
 
@@ -45,10 +45,10 @@ class SimpleProto3(google.protobuf.message.Message):
     class _InnerEnum:
         ValueType = typing.NewType('ValueType', builtins.int)
         V: typing_extensions.TypeAlias = ValueType
-    class _InnerEnumEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_InnerEnum.ValueType], builtins.type):
+    class _InnerEnumEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[SimpleProto3._InnerEnum.ValueType], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
-        INNER1: SimpleProto3.InnerEnum.ValueType  # 0
-        INNER2: SimpleProto3.InnerEnum.ValueType  # 1
+        INNER1: SimpleProto3._InnerEnum.ValueType  # 0
+        INNER2: SimpleProto3._InnerEnum.ValueType  # 1
     class InnerEnum(_InnerEnum, metaclass=_InnerEnumEnumTypeWrapper):
         pass
 

--- a/test/generated/testproto/test_pb2.pyi
+++ b/test/generated/testproto/test_pb2.pyi
@@ -26,10 +26,10 @@ class _OuterEnum:
     V: typing_extensions.TypeAlias = ValueType
 class _OuterEnumEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_OuterEnum.ValueType], builtins.type):
     DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
-    FOO: OuterEnum.ValueType  # 1
+    FOO: _OuterEnum.ValueType  # 1
     """FOO"""
 
-    BAR: OuterEnum.ValueType  # 2
+    BAR: _OuterEnum.ValueType  # 2
     """BAR"""
 
 class OuterEnum(_OuterEnum, metaclass=_OuterEnumEnumTypeWrapper):
@@ -73,12 +73,12 @@ class Simple1(google.protobuf.message.Message):
     class _InnerEnum:
         ValueType = typing.NewType('ValueType', builtins.int)
         V: typing_extensions.TypeAlias = ValueType
-    class _InnerEnumEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_InnerEnum.ValueType], builtins.type):
+    class _InnerEnumEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[Simple1._InnerEnum.ValueType], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
-        INNER1: Simple1.InnerEnum.ValueType  # 1
+        INNER1: Simple1._InnerEnum.ValueType  # 1
         """INNER1"""
 
-        INNER2: Simple1.InnerEnum.ValueType  # 2
+        INNER2: Simple1._InnerEnum.ValueType  # 2
         """INNER2"""
 
     class InnerEnum(_InnerEnum, metaclass=_InnerEnumEnumTypeWrapper):
@@ -257,9 +257,9 @@ class PythonReservedKeywords(google.protobuf.message.Message):
     class _finally:
         ValueType = typing.NewType('ValueType', builtins.int)
         V: typing_extensions.TypeAlias = ValueType
-    class _finallyEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_finally.ValueType], builtins.type):
+    class _finallyEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[PythonReservedKeywords._finally.ValueType], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
-        valid_in_finally: PythonReservedKeywords._r_finally.ValueType  # 2
+        valid_in_finally: PythonReservedKeywords._finally.ValueType  # 2
     class _r_finally(_finally, metaclass=_finallyEnumTypeWrapper):
         pass
 

--- a/test/test_generated_mypy.py
+++ b/test/test_generated_mypy.py
@@ -14,7 +14,7 @@ import pytest
 import sys
 
 from google.protobuf.descriptor import FieldDescriptor
-from google.protobuf.internal import api_implementation  # type: ignore
+from google.protobuf.internal import api_implementation
 from google.protobuf.message import Message
 
 import testproto.test_pb2 as test_pb2


### PR DESCRIPTION
This ensures we're not relying on any forward references.