### PR TITLE
Prep 5.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Upcoming
+## 5.0.0
 
 - Use `builtins.property` to handle conflicts with fields named `property`
 - Mangle all non provided message type imports, this prevents conflicts with field names like `collections`, `builtins`, etc.

--- a/mypy_protobuf/main.py
+++ b/mypy_protobuf/main.py
@@ -26,7 +26,7 @@ from google.protobuf.internal.well_known_types import WKTBASES
 
 from . import extensions_pb2
 
-__version__ = "4.0.0"
+__version__ = "5.0.0"
 
 # SourceCodeLocation is defined by `message Location` here
 # https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/descriptor.proto

--- a/run_test.sh
+++ b/run_test.sh
@@ -95,10 +95,10 @@ MYPY_PROTOBUF_VENV=venv_$PY_VER_MYPY_PROTOBUF
     source "$MYPY_PROTOBUF_VENV"/bin/activate
 
     # Confirm version number
-    test "$(protoc-gen-mypy -V)" = "mypy-protobuf 4.0.0"
-    test "$(protoc-gen-mypy --version)" = "mypy-protobuf 4.0.0"
-    test "$(protoc-gen-mypy_grpc -V)" = "mypy-protobuf 4.0.0"
-    test "$(protoc-gen-mypy_grpc --version)" = "mypy-protobuf 4.0.0"
+    test "$(protoc-gen-mypy -V)" = "mypy-protobuf 5.0.0"
+    test "$(protoc-gen-mypy --version)" = "mypy-protobuf 5.0.0"
+    test "$(protoc-gen-mypy_grpc -V)" = "mypy-protobuf 5.0.0"
+    test "$(protoc-gen-mypy_grpc --version)" = "mypy-protobuf 5.0.0"
 
     # Run mypy on mypy-protobuf internal code for developers to catch issues
     FILES="mypy_protobuf/main.py"


### PR DESCRIPTION
* Breaking change because the import paths change so if people were manipulating input paths, they are now different.